### PR TITLE
l2beat mod to use slug

### DIFF
--- a/src/op_analytics/cli/subcommands/pulls/l2beat.py
+++ b/src/op_analytics/cli/subcommands/pulls/l2beat.py
@@ -57,7 +57,7 @@ def pull():
     )
     urls = {}
     for project in projects:
-        project_id = project["id"]
+        project_id = project["slug"]
         urls[project_id] = f"https://l2beat.com/api/scaling/tvl/{project_id}?range={query_range}"
 
     # Run requests concurrenetly.


### PR DESCRIPTION
Modify L2Beat TVL pull to use the slug, not id in order to find the detailed chain data