### PR TITLE
Add duckdb common functions to be shared across intermediate model definitions

### DIFF
--- a/packages/op-datasets/src/op_datasets/etl/intermediate/construct.py
+++ b/packages/op-datasets/src/op_datasets/etl/intermediate/construct.py
@@ -26,6 +26,10 @@ def construct_tasks(
 
     # Load python functions that define registered data models.
     load_model_definitions()
+
+    # Load shared DuckDB UDFs.
+    create_duckdb_macros()
+
     date_range = DateRange.from_spec(range_spec)
 
     tasks = []

--- a/packages/op-datasets/src/op_datasets/etl/intermediate/udfs.py
+++ b/packages/op-datasets/src/op_datasets/etl/intermediate/udfs.py
@@ -7,6 +7,8 @@ from op_coreutils.duckdb_inmem import init_client
 
 @dataclass
 class Expression:
+    """Helper class to hold the definition of an expression along with its alias."""
+
     alias: str
     sql_expr: str
 

--- a/packages/op-datasets/src/op_datasets/etl/intermediate/udfs.py
+++ b/packages/op-datasets/src/op_datasets/etl/intermediate/udfs.py
@@ -1,0 +1,59 @@
+"""DuckDB UDFs that are shared across intermediate models."""
+
+from dataclasses import dataclass
+
+from op_coreutils.duckdb_inmem import init_client
+
+
+@dataclass
+class Expression:
+    alias: str
+    sql_expr: str
+
+    @property
+    def expr(self):
+        return self.sql_expr + " AS " + self.alias
+
+
+def to_sql(exprs: list[Expression]):
+    """Convert a list of expressions to a string that can be used as part of a SELECT."""
+    return ",\n    ".join([_.expr for _ in exprs])
+
+
+def create_duckdb_macros():
+    """Create general purpose macros on the DuckDB in-memory client.
+
+    These macros can be used as part of data model definitions.
+    """
+    client = init_client()
+
+    client.sql("""
+    CREATE OR REPLACE MACRO wei_to_eth(a)
+    AS a::DECIMAL(28, 0) * 0.000000000000000001::DECIMAL(19, 19);
+
+    CREATE OR REPLACE MACRO wei_to_gwei(a)
+    AS a::DECIMAL(28, 0) * 0.000000001::DECIMAL(10, 10);
+
+    CREATE OR REPLACE MACRO safe_div(a, b) AS
+    IF(b = 0, NULL, a / b);
+    """)
+
+    # Return the client for convenience when writing unit tests.
+    # Tests can use the client to run sql queries that exercise the defined macros.
+    return client
+
+
+# The functions below are defined for cosmetic purposes. When used they add syntax highlighting
+# to SQL expressions which makes them easier to read.
+
+
+def wei_to_eth(x):
+    return f"wei_to_eth({x})"
+
+
+def wei_to_gwei(x):
+    return f"wei_to_gwei({x})"
+
+
+def safe_div(x, y):
+    return f"safe_div({x}, {y})"

--- a/tests/op_datasets/etl/intermediate/test_udfs.py
+++ b/tests/op_datasets/etl/intermediate/test_udfs.py
@@ -1,0 +1,51 @@
+from decimal import Decimal
+
+from op_datasets.etl.intermediate.udfs import (
+    create_duckdb_macros,
+    Expression,
+    safe_div,
+    wei_to_eth,
+    wei_to_gwei,
+    to_sql,
+)
+
+
+def test_macros():
+    client = create_duckdb_macros()
+
+    client.sql("""
+    CREATE TABLE test_macros AS 
+    SELECT 
+        100::BIGINT AS gas_price,
+        200::BIGINT AS receipt_gas_used,
+        0 AS zero,
+        50 as fifty
+    """)
+
+    # Use the Expression class to create the sql.
+    exprs = [
+        Expression(alias="ans_eth", sql_expr=wei_to_eth("gas_price * receipt_gas_used")),
+        Expression(alias="ans_gwei", sql_expr=wei_to_gwei("gas_price * receipt_gas_used")),
+        Expression(alias="ans_division_ok", sql_expr=safe_div("receipt_gas_used", "fifty")),
+        Expression(alias="ans_division_err", sql_expr=safe_div("receipt_gas_used", "zero")),
+    ]
+    result1 = client.sql(f"""
+    SELECT gas_price * receipt_gas_used, {to_sql(exprs)} FROM test_macros
+    """)
+    actual1 = result1.fetchall()
+    expected = [(20000, Decimal("2.00000E-14"), Decimal("0.0000200000"), 4.0, None)]
+
+    assert actual1 == expected
+
+    # Use raw sql.
+    result2 = client.sql("""
+    SELECT
+        gas_price * receipt_gas_used,
+        wei_to_eth(gas_price * receipt_gas_used) AS ans_eth,
+        wei_to_gwei(gas_price * receipt_gas_used) AS ans_gwei,
+        safe_div(receipt_gas_used, fifty) AS ans_division_ok,
+        safe_div(receipt_gas_used, zero) AS ans_division_err
+    FROM test_macros
+    """)
+    actual2 = result2.fetchall()
+    assert actual2 == expected


### PR DESCRIPTION
I have been evaluating DuckDB vs Polars for our model definitions. DuckDB has much better support for working directly in SQL and offers a very convenient way to registered shared macros.  So I'm going to suggest that we switch from Polars to DuckDb as the query layer that we use to operate on parquet data for intermediate models.

This PR introduces some shared macros that can be used when defining intermediate data models. 

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
