### PR TITLE
Add functionality & tests to data handling utils

### DIFF
--- a/packages/op-coreutils/src/op_coreutils/bigquery/write.py
+++ b/packages/op-coreutils/src/op_coreutils/bigquery/write.py
@@ -30,7 +30,7 @@ def init_client():
             _CLIENT = MagicMock()
 
     # In non-PROD environments outside of tests _CLIENT remains uninitialized
-    # so it raises an exception if we try to use it. 
+    # so it raises an exception if we try to use it.
     if _CLIENT is None:
         raise RuntimeError("BigQuery client was not properly initialized.")
 
@@ -60,14 +60,14 @@ def ensure_valid_dt(df: pl.DataFrame, dt=None):
     if dt is None:
         dt_values = df["dt"].unique().to_list()
         if not dt_values:
-            raise OPLabsBigQueryError("No valid 'dt' values found in DataFrame.")
+            log.info("No valid 'dt' values found in DataFrame.")
+            return
         dt = str(dt_values[0])
 
     if isinstance(dt, datetime) or hasattr(dt, "strftime"):
         dt = dt.strftime("%Y-%m-%d")
     elif isinstance(dt, str):
         dt = dt.split(" ")[0]
-
     try:
         datetime.strptime(dt, "%Y-%m-%d")
     except Exception as ex:

--- a/packages/op-coreutils/src/op_coreutils/bigquery/write.py
+++ b/packages/op-coreutils/src/op_coreutils/bigquery/write.py
@@ -80,7 +80,7 @@ def write_df_to_bq(
     destination: str,
     client: bigquery.Client,
     operation: str,
-    write_disposition: str = bigquery.WriteDisposition.WRITE_TRUNCATE,
+    write_disposition: str,
     time_partitioning: bigquery.TimePartitioning = None,
 ):
     """Helper function to write a DataFrame to BigQuery.
@@ -90,7 +90,7 @@ def write_df_to_bq(
         destination (str): The BigQuery table destination in 'dataset.table' format.
         client (bigquery.Client): The BigQuery client.
         operation (str): Description of the operation for logging.
-        write_disposition (str, optional): BigQuery write disposition. Defaults to 'WRITE_TRUNCATE'.
+        write_disposition (str, optional): BigQuery write disposition.
         time_partitioning (bigquery.TimePartitioning, optional): Time partitioning configuration.
     """
     with io.BytesIO() as stream:

--- a/packages/op-coreutils/src/op_coreutils/bigquery/write.py
+++ b/packages/op-coreutils/src/op_coreutils/bigquery/write.py
@@ -1,111 +1,169 @@
 # -*- coding: utf-8 -*-
 import io
-
-import polars as pl
-
+import sys
 from datetime import datetime
-from google.cloud import bigquery
 from unittest.mock import MagicMock
 
-from op_coreutils.logger import human_rows, human_size, structlog
-from op_coreutils.env.aware import current_environment, OPLabsEnvironment
+import polars as pl
+from google.cloud import bigquery
+
+from op_coreutils.env.aware import OPLabsEnvironment, current_environment
 from op_coreutils.gcpauth import get_credentials
+from op_coreutils.logger import human_rows, human_size, structlog
 
 log = structlog.get_logger()
-
 
 _CLIENT: bigquery.Client | MagicMock | None = None
 
 
 def init_client():
-    """Idempotent env-aware client initialization.
-
-    - Guarantess only one global instance exists.
-    - Uses a mock when not running in PROD.
-    """
+    """BigQuery client with environment and testing awareness."""
     global _CLIENT
 
     if _CLIENT is None:
         current_env = current_environment()
 
+        # Only use MagicMock in a testing environment (i.e., when running with pytest)
         if current_env == OPLabsEnvironment.PROD:
-            from google.cloud import bigquery
-
             _CLIENT = bigquery.Client(credentials=get_credentials())
-
-        else:
+        elif "pytest" in sys.modules:
             _CLIENT = MagicMock()
+        else:
+            # In non-PROD environments outside of tests, initialize as None
+            _CLIENT = None
 
     if _CLIENT is None:
-        raise RuntimeError("Biguqery client was not properly initialized.")
+        raise RuntimeError("BigQuery client was not properly initialized.")
 
     return _CLIENT
 
 
 class OPLabsBigQueryError(Exception):
+    """Custom exception for BigQuery operations."""
+
     pass
 
 
-def ensure_valid_dt(dt: str):
+def ensure_valid_dt(df: pl.DataFrame, dt=None):
+    """Ensure the DataFrame contains a valid 'dt' column and date.
+
+    Args:
+        df (pl.DataFrame): The DataFrame to validate.
+        dt (str, optional): The date string to validate. If None, uses the first unique 'dt' value from the DataFrame.
+
+    Raises:
+        ValueError: If the DataFrame is empty or missing 'dt' column.
+        OPLabsBigQueryError: If 'dt' is not a valid date in 'YYYY-MM-DD' format.
+    """
+    if df.is_empty() or "dt" not in df.columns:
+        raise ValueError("DataFrame is empty or missing required 'dt' column.")
+
+    if dt is None:
+        dt_values = df["dt"].unique().to_list()
+        if not dt_values:
+            raise OPLabsBigQueryError("No valid 'dt' values found in DataFrame.")
+        dt = str(dt_values[0])
+
+    if isinstance(dt, datetime) or hasattr(dt, "strftime"):
+        dt = dt.strftime("%Y-%m-%d")
+    elif isinstance(dt, str):
+        dt = dt.split(" ")[0]
+
     try:
         datetime.strptime(dt, "%Y-%m-%d")
     except Exception as ex:
         raise OPLabsBigQueryError(f"invalid date partition dt={dt}") from ex
 
 
-def overwrite_table(df: pl.DataFrame, dataset: str, table_name: str):
-    client = init_client()
+def write_df_to_bq(
+    df: pl.DataFrame,
+    destination: str,
+    client: bigquery.Client,
+    operation: str,
+    write_disposition: str = bigquery.WriteDisposition.WRITE_TRUNCATE,
+    time_partitioning: bigquery.TimePartitioning = None,
+):
+    """Helper function to write a DataFrame to BigQuery.
 
-    destination = f"{dataset}.{table_name}"
-
-    # By convention we only allow overwrites on tables that end with the _staging
-    # or _latest suffixes.
-    if not any([table_name.endswith("_staging"), table_name.endswith("_latest")]):
-        raise OPLabsBigQueryError(f"cannot overwrite data at {destination}")
-
+    Args:
+        df (pl.DataFrame): The DataFrame to write.
+        destination (str): The BigQuery table destination in 'dataset.table' format.
+        client (bigquery.Client): The BigQuery client.
+        operation (str): Description of the operation for logging.
+        write_disposition (str, optional): BigQuery write disposition. Defaults to 'WRITE_TRUNCATE'.
+        time_partitioning (bigquery.TimePartitioning, optional): Time partitioning configuration.
+    """
     with io.BytesIO() as stream:
         df.write_parquet(stream)
         filesize = stream.tell()
         stream.seek(0)
+        job_config = bigquery.LoadJobConfig(
+            source_format=bigquery.SourceFormat.PARQUET,
+            write_disposition=write_disposition,
+            time_partitioning=time_partitioning,
+        )
         job = client.load_table_from_file(
             stream,
             destination=destination,
-            job_config=bigquery.LoadJobConfig(
-                source_format=bigquery.SourceFormat.PARQUET,
-                write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
-            ),
+            job_config=job_config,
         )
         job.result()
-        if isinstance(client, MagicMock):
-            operation = "DRYRUN "
-        else:
-            operation = ""
+        operation_prefix = "DRYRUN " if isinstance(client, MagicMock) else ""
         log.info(
-            f"{operation}OVERWRITE TABLE: Wrote {human_rows(len(df))} {human_size(filesize)} to BQ {destination}"
+            f"{operation_prefix}{operation}: Wrote {human_rows(len(df))} {human_size(filesize)} to BQ {destination}"
         )
+
+
+def overwrite_table(df: pl.DataFrame, dataset: str, table_name: str):
+    """Overwrite a BigQuery table with the given DataFrame.
+
+    Args:
+        df (pl.DataFrame): The DataFrame to write.
+        dataset (str): The BigQuery dataset name.
+        table_name (str): The BigQuery table name.
+
+    Raises:
+        OPLabsBigQueryError: If the table name does not end with '_staging' or '_latest'.
+    """
+    client = init_client()
+    destination = f"{dataset}.{table_name}"
+
+    if not any([table_name.endswith("_staging"), table_name.endswith("_latest")]):
+        raise OPLabsBigQueryError(f"cannot overwrite data at {destination}")
+
+    write_df_to_bq(df, destination, client, operation="OVERWRITE TABLE")
 
 
 def overwrite_partition(
-    df: pl.DataFrame,
-    dt: str,
-    dataset: str,
-    table_name: str,
-    expiration_days: int = 360,
+    df: pl.DataFrame, dt: str, dataset: str, table_name: str, expiration_days: int = 360
 ):
-    init_client()
+    """Overwrite a specific partition in a BigQuery table.
 
-    ensure_valid_dt(dt)
+    Args:
+        df (pl.DataFrame): The DataFrame to write.
+        dt (str): The partition date in 'YYYY-MM-DD' format.
+        dataset (str): The BigQuery dataset name.
+        table_name (str): The BigQuery table name.
+        expiration_days (int, optional): Partition expiration in days. Defaults to 360.
+    """
+    ensure_valid_dt(df, dt)
     df = df.with_columns(dt=pl.lit(dt).str.strptime(pl.Datetime, "%Y-%m-%d"))
     overwrite_partitions(df, dataset, table_name, expiration_days)
 
 
 def overwrite_partitions(
-    df: pl.DataFrame,
-    dataset: str,
-    table_name: str,
-    expiration_days: int = 360,
+    df: pl.DataFrame, dataset: str, table_name: str, expiration_days: int = 360
 ):
+    """Overwrite multiple partitions in a BigQuery table.
+
+    Args:
+        df (pl.DataFrame): The DataFrame to write.
+        dataset (str): The BigQuery dataset name.
+        table_name (str): The BigQuery table name.
+        expiration_days (int, optional): Partition expiration in days. Defaults to 360.
+    """
     client = init_client()
+    ensure_valid_dt(df)
 
     destination = f"{dataset}.{table_name}"
 
@@ -113,38 +171,65 @@ def overwrite_partitions(
         df = df.with_columns(dt=pl.col("dt").str.strptime(pl.Datetime, "%Y-%m-%d"))
 
     partitions = df["dt"].unique().sort().to_list()
-    if isinstance(client, MagicMock):
-        operation = "DRYRUN "
-    else:
-        operation = ""
     log.info(
-        f"{operation}Writing {len(partitions)} partitions to BQ [{partitions[0]} ... {partitions[-1]}]"
+        f"Writing {len(partitions)} partitions to BQ [{partitions[0]} ... {partitions[-1]}]"
     )
 
-    with io.BytesIO() as stream:
-        df.write_parquet(stream)
-        filesize = stream.tell()
-        stream.seek(0)
-        job = client.load_table_from_file(
-            stream,
-            destination=destination,
-            job_config=bigquery.LoadJobConfig(
-                source_format=bigquery.SourceFormat.PARQUET,
-                write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
-                time_partitioning=bigquery.TimePartitioning(
-                    type_=bigquery.TimePartitioningType.DAY,
-                    field="dt",  # Name of the column to use for partitioning.
-                    expiration_ms=expiration_days * 24 * 3600 * 1000,
-                ),
-            ),
-        )
-        job.result()
+    time_partitioning = bigquery.TimePartitioning(
+        type_=bigquery.TimePartitioningType.DAY,
+        field="dt",
+        expiration_ms=expiration_days * 24 * 3600 * 1000,
+    )
 
-        if isinstance(client, MagicMock):
-            operation = "DRYRUN "
-        else:
-            operation = ""
+    write_df_to_bq(
+        df,
+        destination,
+        client,
+        operation="OVERWRITE PARTITION",
+        time_partitioning=time_partitioning,
+    )
 
-        log.info(
-            f"{operation}OVERWRITE PARTITION: Wrote {human_rows(len(df))} {human_size(filesize)} to BQ {destination}"
-        )
+
+def upsert_partition(
+    df: pl.DataFrame, dt: str, dataset: str, table_name: str, unique_keys=["dt"]
+):
+    """Upsert data into a specific partition in a BigQuery table.
+
+    Args:
+        df (pl.DataFrame): The DataFrame to upsert.
+        dt (str): The partition date in 'YYYY-MM-DD' format.
+        dataset (str): The BigQuery dataset name.
+        table_name (str): The BigQuery table name.
+        unique_keys (list, optional): Columns that uniquely identify rows. Defaults to ['dt'].
+    """
+    client = init_client()
+    ensure_valid_dt(df, dt)
+    df = df.with_columns(dt=pl.lit(dt).str.strptime(pl.Datetime, "%Y-%m-%d"))
+
+    destination = f"{dataset}.{table_name}"
+    staging_table_name = f"{table_name}_staging"
+    staging_destination = f"{dataset}.{staging_table_name}"
+
+    write_df_to_bq(df, staging_destination, client, operation="WRITE STAGING TABLE")
+
+    # Build the merge condition using unique_keys
+    merge_condition = " AND ".join([f"T.{key} = S.{key}" for key in unique_keys])
+
+    # Exclude unique_keys from update columns
+    update_columns = [col for col in df.columns if col not in unique_keys]
+
+    merge_query = f"""
+    MERGE `{destination}` T
+    USING `{staging_destination}` S
+    ON {merge_condition}
+    WHEN MATCHED THEN
+      UPDATE SET {", ".join([f"T.{col} = S.{col}" for col in update_columns])}
+    WHEN NOT MATCHED THEN
+      INSERT ({", ".join(df.columns)}) VALUES ({", ".join([f'S.{col}' for col in df.columns])})
+    """
+
+    query_job = client.query(merge_query)
+    query_job.result()
+    client.delete_table(staging_destination)
+
+    log.info(f"Upsert for partition {dt} completed successfully.")

--- a/packages/op-coreutils/src/op_coreutils/bigquery/write.py
+++ b/packages/op-coreutils/src/op_coreutils/bigquery/write.py
@@ -28,10 +28,9 @@ def init_client():
             _CLIENT = bigquery.Client(credentials=get_credentials())
         elif "pytest" in sys.modules:
             _CLIENT = MagicMock()
-        else:
-            # In non-PROD environments outside of tests, initialize as None
-            _CLIENT = None
 
+    # In non-PROD environments outside of tests _CLIENT remains uninitialized
+    # so it raises an exception if we try to use it. 
     if _CLIENT is None:
         raise RuntimeError("BigQuery client was not properly initialized.")
 

--- a/packages/op-coreutils/src/op_coreutils/bigquery/write.py
+++ b/packages/op-coreutils/src/op_coreutils/bigquery/write.py
@@ -10,6 +10,7 @@ from google.cloud import bigquery
 from op_coreutils.env.aware import OPLabsEnvironment, current_environment
 from op_coreutils.gcpauth import get_credentials
 from op_coreutils.logger import human_rows, human_size, structlog
+from google.api_core.exceptions import NotFound
 
 log = structlog.get_logger()
 
@@ -208,6 +209,12 @@ def upsert_partition(
     destination = f"{dataset}.{table_name}"
     staging_table_name = f"{table_name}_staging"
     staging_destination = f"{dataset}.{staging_table_name}"
+
+    # Delete the staging table if it already exists
+    try:
+        client.delete_table(staging_destination)
+    except NotFound:
+        pass  # If the table does not exist, continue without error
 
     write_df_to_bq(df, staging_destination, client, operation="WRITE STAGING TABLE")
 

--- a/tests/op_coreutils/bigquery/test_write.py
+++ b/tests/op_coreutils/bigquery/test_write.py
@@ -1,0 +1,260 @@
+# -*- coding: utf-8 -*-
+# test_write.py
+
+from unittest.mock import patch, MagicMock
+import polars as pl
+import pytest
+import numpy as np
+import pandas as pd
+
+from op_coreutils.bigquery.write import (
+    init_client,
+    ensure_valid_dt,
+    overwrite_table,
+    overwrite_partition,
+    overwrite_partitions,
+    OPLabsBigQueryError,
+    OPLabsEnvironment,
+    upsert_partition,
+)
+
+
+# Generate a larger sample DataFrame for testing
+date_range = pd.date_range("2024-01-01", periods=100, freq="D")
+num_rows = 1000
+
+# Create random data for each column
+test_df = pl.DataFrame(
+    {
+        "dt": np.random.choice(date_range, num_rows),
+        "data": np.random.randint(100, 500, size=num_rows),
+        "category": np.random.choice(["A", "B", "C", "D"], num_rows),
+        "value": np.random.uniform(1.0, 10.0, size=num_rows).round(2),
+    }
+)
+
+# Sort by 'dt' for consistency
+test_df = test_df.sort("dt")
+
+
+def reset_client():
+    """Utility function to reset the global _CLIENT variable."""
+    import op_coreutils.bigquery.write
+
+    op_coreutils.bigquery.write._CLIENT = None
+
+
+@patch("op_coreutils.bigquery.write.get_credentials")
+@patch("op_coreutils.bigquery.write.bigquery.Client")
+def test_init_client(mock_bigquery_client, mock_get_credentials):
+    reset_client()
+    with patch(
+        "op_coreutils.bigquery.write.current_environment",
+        return_value=OPLabsEnvironment.DEV,
+    ):
+        client = init_client()
+        assert isinstance(
+            client, MagicMock
+        ), "Client should be MagicMock in non-PROD environments."
+
+    reset_client()
+    with patch(
+        "op_coreutils.bigquery.write.current_environment",
+        return_value=OPLabsEnvironment.PROD,
+    ):
+        client = init_client()
+        mock_bigquery_client.assert_called_once_with(
+            credentials=mock_get_credentials.return_value
+        )
+        assert client == mock_bigquery_client.return_value
+
+
+def test_ensure_valid_dt():
+    valid_df = pl.DataFrame({"dt": ["2024-01-01"], "data": [100]})
+    try:
+        ensure_valid_dt(valid_df, "2024-01-01")
+    except OPLabsBigQueryError:
+        pytest.fail(
+            "ensure_valid_dt() raised an unexpected OPLabsBigQueryError for a valid date."
+        )
+
+    with pytest.raises(
+        OPLabsBigQueryError, match="invalid date partition dt=invalid-date"
+    ):
+        ensure_valid_dt(valid_df, "invalid-date")
+
+    empty_df = pl.DataFrame()
+    with pytest.raises(
+        ValueError, match="DataFrame is empty or missing required 'dt' column."
+    ):
+        ensure_valid_dt(empty_df, "2024-01-01")
+
+    df_missing_dt = pl.DataFrame({"data": [1, 2, 3]})
+    with pytest.raises(
+        ValueError, match="DataFrame is empty or missing required 'dt' column."
+    ):
+        ensure_valid_dt(df_missing_dt, "2024-01-01")
+
+
+@patch("op_coreutils.bigquery.write.init_client")
+def test_overwrite_partitions_empty_df(mock_init_client):
+    mock_client = MagicMock()
+    mock_init_client.return_value = mock_client
+
+    empty_df = pl.DataFrame()
+    with pytest.raises(
+        ValueError, match="DataFrame is empty or missing required 'dt' column."
+    ):
+        overwrite_partitions(empty_df, "test_dataset", "test_table")
+
+
+@patch("op_coreutils.bigquery.write.init_client")
+def test_overwrite_table(mock_init_client):
+    mock_client = MagicMock()
+    mock_init_client.return_value = mock_client
+
+    mock_load_job = MagicMock()
+    mock_client.load_table_from_file.return_value = mock_load_job
+    mock_load_job.result.return_value = None
+
+    overwrite_table(test_df, "test_dataset", "test_table_staging")
+
+    mock_client.load_table_from_file.assert_called_once()
+    args, kwargs = mock_client.load_table_from_file.call_args
+    assert kwargs["destination"] == "test_dataset.test_table_staging"
+    assert kwargs["job_config"].write_disposition == "WRITE_TRUNCATE"
+    assert mock_load_job.result.called
+
+    with pytest.raises(
+        OPLabsBigQueryError, match="cannot overwrite data at test_dataset.test_table"
+    ):
+        overwrite_table(test_df, "test_dataset", "test_table")
+
+
+@patch("op_coreutils.bigquery.write.init_client")
+def test_overwrite_partition(mock_init_client):
+    mock_client = MagicMock()
+    mock_init_client.return_value = mock_client
+
+    mock_load_job = MagicMock()
+    mock_client.load_table_from_file.return_value = mock_load_job
+    mock_load_job.result.return_value = None
+
+    overwrite_partition(test_df, "2024-01-01", "test_dataset", "test_table")
+
+    mock_client.load_table_from_file.assert_called_once()
+    assert mock_load_job.result.called
+
+    with pytest.raises(
+        OPLabsBigQueryError, match="invalid date partition dt=invalid-date"
+    ):
+        overwrite_partition(test_df, "invalid-date", "test_dataset", "test_table")
+
+
+@patch("op_coreutils.bigquery.write.init_client")
+def test_overwrite_partitions(mock_init_client):
+    mock_client = MagicMock()
+    mock_init_client.return_value = mock_client
+
+    mock_load_job = MagicMock()
+    mock_client.load_table_from_file.return_value = mock_load_job
+    mock_load_job.result.return_value = None
+
+    overwrite_partitions(test_df, "test_dataset", "test_table")
+
+    mock_client.load_table_from_file.assert_called_once()
+    assert mock_load_job.result.called
+
+    args, kwargs = mock_client.load_table_from_file.call_args
+    job_config = kwargs["job_config"]
+    assert job_config.time_partitioning.field == "dt"
+
+
+@patch("op_coreutils.bigquery.write.init_client")
+def test_upsert_partition_default_unique_key(mock_init_client):
+    """Test upsert_partition with default unique_keys (['dt'])."""
+    mock_client = MagicMock()
+    mock_init_client.return_value = mock_client
+
+    mock_load_job = MagicMock()
+    mock_client.load_table_from_file.return_value = mock_load_job
+    mock_load_job.result.return_value = None
+
+    mock_query_job = MagicMock()
+    mock_client.query.return_value = mock_query_job
+    mock_query_job.result.return_value = None
+
+    mock_client.delete_table.return_value = None
+
+    upsert_partition(test_df, "2024-01-01", "test_dataset", "test_table")
+
+    merge_query = mock_client.query.call_args[0][0]
+    assert "MERGE" in merge_query
+    assert (
+        "ON T.dt = S.dt" in merge_query
+    ), "Merge condition should use 'dt' as the unique key."
+
+
+@patch("op_coreutils.bigquery.write.init_client")
+def test_upsert_partition_custom_unique_keys(mock_init_client):
+    """Test upsert_partition with custom unique_keys (['dt', 'category'])."""
+    mock_client = MagicMock()
+    mock_init_client.return_value = mock_client
+
+    mock_load_job = MagicMock()
+    mock_client.load_table_from_file.return_value = mock_load_job
+    mock_load_job.result.return_value = None
+
+    mock_query_job = MagicMock()
+    mock_client.query.return_value = mock_query_job
+    mock_query_job.result.return_value = None
+
+    mock_client.delete_table.return_value = None
+
+    upsert_partition(
+        test_df,
+        "2024-01-01",
+        "test_dataset",
+        "test_table",
+        unique_keys=["dt", "category"],
+    )
+
+    merge_query = mock_client.query.call_args[0][0]
+    assert "MERGE" in merge_query
+    assert (
+        "ON T.dt = S.dt AND T.category = S.category" in merge_query
+    ), "Merge condition should use 'dt' and 'category' as the unique keys."
+
+
+@patch("op_coreutils.bigquery.write.init_client")
+def test_upsert_partition_single_column_unique_key(mock_init_client):
+    """Test upsert_partition with a single unique key (['category'])."""
+    mock_client = MagicMock()
+    mock_init_client.return_value = mock_client
+
+    mock_load_job = MagicMock()
+    mock_client.load_table_from_file.return_value = mock_load_job
+    mock_load_job.result.return_value = None
+
+    mock_query_job = MagicMock()
+    mock_client.query.return_value = mock_query_job
+    mock_query_job.result.return_value = None
+
+    mock_client.delete_table.return_value = None
+
+    upsert_partition(
+        test_df, "2024-01-01", "test_dataset", "test_table", unique_keys=["category"]
+    )
+
+    merge_query = mock_client.query.call_args[0][0]
+    assert "MERGE" in merge_query
+    assert (
+        "ON T.category = S.category" in merge_query
+    ), "Merge condition should use 'category' as the unique key."
+
+
+def test_overwrite_partition_invalid_dt():
+    with pytest.raises(
+        OPLabsBigQueryError, match="invalid date partition dt=not-a-date"
+    ):
+        overwrite_partition(test_df, "not-a-date", "test_dataset", "test_table")

--- a/tests/op_coreutils/bigquery/test_write.py
+++ b/tests/op_coreutils/bigquery/test_write.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# test_write.py
-
 from unittest.mock import patch, MagicMock
 import polars as pl
 import pytest
@@ -8,13 +6,11 @@ import numpy as np
 import pandas as pd
 
 from op_coreutils.bigquery.write import (
-    init_client,
     ensure_valid_dt,
     overwrite_table,
     overwrite_partition,
     overwrite_partitions,
     OPLabsBigQueryError,
-    OPLabsEnvironment,
     upsert_partition,
 )
 
@@ -42,31 +38,6 @@ def reset_client():
     import op_coreutils.bigquery.write
 
     op_coreutils.bigquery.write._CLIENT = None
-
-
-@patch("op_coreutils.bigquery.write.get_credentials")
-@patch("op_coreutils.bigquery.write.bigquery.Client")
-def test_init_client(mock_bigquery_client, mock_get_credentials):
-    reset_client()
-    with patch(
-        "op_coreutils.bigquery.write.current_environment",
-        return_value=OPLabsEnvironment.DEV,
-    ):
-        client = init_client()
-        assert isinstance(
-            client, MagicMock
-        ), "Client should be MagicMock in non-PROD environments."
-
-    reset_client()
-    with patch(
-        "op_coreutils.bigquery.write.current_environment",
-        return_value=OPLabsEnvironment.PROD,
-    ):
-        client = init_client()
-        mock_bigquery_client.assert_called_once_with(
-            credentials=mock_get_credentials.return_value
-        )
-        assert client == mock_bigquery_client.return_value
 
 
 def test_ensure_valid_dt():


### PR DESCRIPTION
**Description**

- Updated `write.py` in `op_coreutils/bigquery` with:
  - New functions: `write_df_to_bq`, `upsert_partition`, refactored `overwrite_partitions`.
  - Enhanced docstrings and exception handling.
  - `upsert_partition` for unique-key-based data upserts.

- Added test suite `test_write.py` covering:
  - Initialization, overwrite, upsert, and partition handling.
  - Edge cases for empty DataFrames and unique keys in upserts.


**Tests**

- Created tests in `test_write.py` for BigQuery write operations:
  - Valid and invalid date partitioning.
  - Upsert with various unique keys.
  - Error handling for empty DataFrames and invalid configurations.