### PR TITLE
Updated existing defillama code to address #887 & improve overall functionality

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,2 +1,0 @@
-# Add directories or file patterns to ignore during indexing (e.g. foo/ or *.csv)
-*.csv

--- a/packages/op-coreutils/src/op_coreutils/bigquery/write.py
+++ b/packages/op-coreutils/src/op_coreutils/bigquery/write.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import io
 from datetime import date, datetime, timedelta, timezone
 from typing import List
@@ -7,16 +6,21 @@ from uuid import uuid4
 
 import polars as pl
 from google.cloud import bigquery
-from google.cloud.exceptions import NotFound
+from google.api_core import exceptions
 
 from op_coreutils.env.aware import OPLabsEnvironment, current_environment
 from op_coreutils.gcpauth import get_credentials
 from op_coreutils.logger import human_rows, human_size, structlog
-from op_coreutils.time import date_fromstr
+from op_coreutils.time import date_fromstr, now
 
 log = structlog.get_logger()
 
 _CLIENT: bigquery.Client | MagicMock | None = None
+
+
+# This dataset is used to store staging tables used in upsert operations.
+# It is already configured with a default table expiration time of 1 day.
+UPSERTS_TEMP_DATASET = "temp_upserts"
 
 
 def init_client():
@@ -107,7 +111,7 @@ def overwrite_partitioned_table(
         df (pl.DataFrame): The DataFrame to write.
         dataset (str): The BigQuery dataset name.
         table_name (str): The BigQuery table name.
-        expiration_days (int, optional): Partition expiration in days.
+        expiration_days (int, optional): If provided sets the expiration time of the table.
     """
 
     # Ensure "dt" is a DateTime
@@ -115,9 +119,7 @@ def overwrite_partitioned_table(
         df = df.with_columns(dt=pl.col("dt").str.strptime(pl.Datetime, "%Y-%m-%d"))
 
     partitions = df["dt"].unique().sort().to_list()
-    log.info(
-        f"Writing {len(partitions)} partitions to BQ [{partitions[0]} ... {partitions[-1]}]"
-    )
+    log.info(f"Writing {len(partitions)} partitions to BQ [{partitions[0]} ... {partitions[-1]}]")
 
     _write_df_to_bq(
         df,
@@ -148,7 +150,7 @@ def overwrite_partitions_dynamic(
         df (pl.DataFrame): The DataFrame to write.
         dataset (str): The BigQuery dataset name.
         table_name (str): The BigQuery table name.
-        expiration_days (int, optional): Partition expiration in days
+        expiration_days (int, optional): If provided sets the expiration time of the table.
     """
 
     # Ensure "dt" is a DateTime
@@ -157,9 +159,7 @@ def overwrite_partitions_dynamic(
 
     partitions = df["dt"].unique().sort().to_list()
 
-    log.info(
-        f"Writing {len(partitions)} partitions to BQ [{partitions[0]} ... {partitions[-1]}]"
-    )
+    log.info(f"Writing {len(partitions)} partitions to BQ [{partitions[0]} ... {partitions[-1]}]")
 
     if len(partitions) > 10:
         raise OPLabsBigQueryError(
@@ -202,7 +202,7 @@ def overwrite_partition_static(
         partition_dt (date): The partition date.
         dataset (str): The BigQuery dataset name.
         table_name (str): The BigQuery table name.
-        expiration_days (int, optional): Partition expiration in days
+        expiration_days (int, optional): If provided sets the expiration time of the table.
     """
     overwrite_partitions_dynamic(
         df=df.with_columns(dt=pl.lit(partition_dt).cast(pl.Datetime)),
@@ -220,7 +220,9 @@ def _days_to_ms(days: int | None) -> int | None:
 
 
 def _write_df_to_bq(
-    df: pl.DataFrame, destination: str, job_config=bigquery.LoadJobConfig
+    df: pl.DataFrame,
+    destination: str,
+    job_config=bigquery.LoadJobConfig,
 ):
     """Helper function to write a DataFrame to BigQuery."""
     client = init_client()
@@ -246,7 +248,6 @@ def upsert_unpartitioned_table(
     dataset: str,
     table_name: str,
     unique_keys: List[str],
-    expiration_minutes: int = 30,
 ):
     """Upsert data into an unpartitioned BigQuery table.
 
@@ -255,23 +256,19 @@ def upsert_unpartitioned_table(
         dataset (str): The BigQuery dataset name.
         table_name (str): The BigQuery table name.
         unique_keys (List[str]): Columns that uniquely identify rows.
-        expiration_minutes (int, optional): Expiration time for the staging table in minutes.
-            Defaults to 30.
+        expiration_days (int, optional): If provided sets the expiration time of the table.
 
     Raises:
         ValueError: If the DataFrame is empty or if unique_keys are not in the DataFrame.
     """
     if "dt" in df.columns:
-        raise ValueError(
-            "DataFrame should not contain 'dt' column for unpartitioned tables."
-        )
+        raise ValueError("DataFrame should not contain 'dt' column for unpartitioned tables.")
 
     _upsert_df_to_bq(
         df=df,
         dataset=dataset,
         table_name=table_name,
         unique_keys=unique_keys,
-        expiration_minutes=expiration_minutes,
     )
 
 
@@ -281,7 +278,6 @@ def upsert_partitioned_table(
     table_name: str,
     unique_keys: List[str],
     partition_dt: str,
-    expiration_minutes: int = 30,
 ):
     """Upsert data into a partitioned BigQuery table.
 
@@ -293,8 +289,6 @@ def upsert_partitioned_table(
         table_name (str): The BigQuery table name.
         unique_keys (List[str]): Columns that uniquely identify rows.
         partition_dt (str): The partition date in 'YYYY-MM-DD' format.
-        expiration_minutes (int, optional): Expiration time for the staging table in minutes.
-            Defaults to 30.
 
     Raises:
         ValueError: If the DataFrame is empty or if unique_keys are not in the DataFrame.
@@ -307,7 +301,6 @@ def upsert_partitioned_table(
         dataset=dataset,
         table_name=table_name,
         unique_keys=unique_keys,
-        expiration_minutes=expiration_minutes,
     )
 
 
@@ -316,7 +309,6 @@ def _upsert_df_to_bq(
     dataset: str,
     table_name: str,
     unique_keys: List[str],
-    expiration_minutes: int = 30,
 ):
     """Helper function to upsert data into a BigQuery table.
 
@@ -325,8 +317,6 @@ def _upsert_df_to_bq(
         dataset (str): The BigQuery dataset name.
         table_name (str): The BigQuery table name.
         unique_keys (List[str]): Columns that uniquely identify rows.
-        expiration_minutes (int, optional): Expiration time for the staging table in minutes.
-            Defaults to 30.
 
     Raises:
         ValueError: If the DataFrame is empty or if unique_keys are not in the DataFrame.
@@ -342,22 +332,23 @@ def _upsert_df_to_bq(
 
     client = init_client()
 
-    # Use a dedicated staging dataset
-    staging_dataset = f"{dataset}_staging"
+    upsert_destination = f"{dataset}.{table_name}"
 
-    # Ensure staging dataset exists
+    # Ensure the upsert destination exists.
     try:
-        client.get_dataset(staging_dataset)
-    except NotFound:
-        dataset_ref = bigquery.Dataset(staging_dataset)
-        client.create_dataset(dataset_ref)
-        log.info(f"Created staging dataset {staging_dataset}")
+        client.get_table(upsert_destination)
+    except exceptions.NotFound:
+        raise OPLabsBigQueryError(
+            f"Cannot upsert into a table that does not exist yet: {upsert_destination}"
+        )
 
-    # Generate a unique staging table name
-    random_suffix = uuid4().hex[:8]
-    staging_table_name = f"{table_name}_staging_{random_suffix}"
-    staging_destination = f"{staging_dataset}.{staging_table_name}"
+    # Generate a unique staging table name. Include the timestamp
+    # in the name for debugging purposes.
+    random_suffix = now().strftime("%Y%m%d%H%M-") + uuid4().hex[:8]
+    staging_table_name = f"{dataset}_{table_name}_{random_suffix}"
+    staging_destination = f"{UPSERTS_TEMP_DATASET}.{staging_table_name}"
 
+    # Write the incoming data to the staging table.
     _write_df_to_bq(
         df,
         staging_destination,
@@ -367,9 +358,10 @@ def _upsert_df_to_bq(
         ),
     )
 
-    # Set expiration time on the staging table
+    # The staging table is not deleted after the process. We keep it around for
+    # 2 hours in case it needs to be used for debugging the MERGE statement.
     table = client.get_table(staging_destination)
-    table.expires = datetime.now(timezone.utc) + timedelta(minutes=expiration_minutes)
+    table.expires = datetime.now(timezone.utc) + timedelta(hours=2)
     client.update_table(table, ["expires"])
 
     # Build the merge condition using unique_keys
@@ -380,24 +372,32 @@ def _upsert_df_to_bq(
 
     # Handle case where there are no columns to update (all columns are unique keys)
     if update_columns:
-        update_statement = (
-            f"UPDATE SET {', '.join([f'T.{col} = S.{col}' for col in update_columns])}"
-        )
+        update_items = ", ".join([f"T.{col} = S.{col}" for col in update_columns])
+        update_statement = f"UPDATE SET {update_items}"
     else:
         update_statement = "NOTHING"
 
+    # Build the insert clause.
+    df_columns = ", ".join(df.columns)
+    df_values = ", ".join([f"S.{col}" for col in df.columns])
+
     merge_query = f"""
-    MERGE `{dataset}.{table_name}` T
+    MERGE `{upsert_destination}` T
     USING `{staging_destination}` S
     ON {merge_condition}
     WHEN MATCHED THEN
       {update_statement}
     WHEN NOT MATCHED THEN
-      INSERT ({', '.join(df.columns)}) VALUES ({', '.join([f'S.{col}' for col in df.columns])})
+      INSERT ({df_columns}) VALUES ({df_values})
     """
+
+    # Print the merge query for debugging purposes.
+    print()
+    print(merge_query)
+    print()
 
     query_job = client.query(merge_query)
     query_job.result()
-    client.delete_table(staging_destination)
 
-    log.info(f"Upsert to table {dataset}.{table_name} completed successfully.")
+    operation_prefix = "DRYRUN " if isinstance(client, MagicMock) else ""
+    log.info(f"{operation_prefix}UPSERT: {human_rows(len(df))} to BQ {upsert_destination}")

--- a/packages/op-coreutils/src/op_coreutils/env/aware.py
+++ b/packages/op-coreutils/src/op_coreutils/env/aware.py
@@ -16,13 +16,12 @@ def current_environment():
     global _CURRENT_ENV
 
     if _CURRENT_ENV is None:
+        oplabs_env = os.environ.get("OPLABS_ENV")
+
         if os.environ.get("PYTEST_VERSION") is not None:
             _CURRENT_ENV = OPLabsEnvironment.UNITTEST
 
-        elif (
-            os.environ.get("OPLABS_ENV") is not None
-            and os.environ.get("OPLABS_ENV").upper() == "PROD"
-        ):
+        elif oplabs_env is not None and oplabs_env.upper() == "PROD":
             _CURRENT_ENV = OPLabsEnvironment.PROD
 
         else:

--- a/packages/op-coreutils/src/op_coreutils/gsheets.py
+++ b/packages/op-coreutils/src/op_coreutils/gsheets.py
@@ -30,7 +30,9 @@ def init_client():
     if _GSHEETS_CLIENT is None:
         _GSHEETS_LOCATIONS = env_get("gsheets")
 
-        if len(_GSHEETS_LOCATIONS) == 0:
+        if _GSHEETS_LOCATIONS is None:
+            _GSHEETS_CLIENT = MagicMock()
+        elif len(_GSHEETS_LOCATIONS) == 0:
             _GSHEETS_CLIENT = MagicMock()
         else:
             scoped_creds = get_credentials().with_scopes(gspread.auth.DEFAULT_SCOPES)

--- a/packages/op-coreutils/src/op_coreutils/partitioned/__init__.py
+++ b/packages/op-coreutils/src/op_coreutils/partitioned/__init__.py
@@ -3,7 +3,7 @@
 from .reader import DataReader, construct_input_batches
 from .location import DataLocation, MarkersLocation
 from .marker import Marker, markers_for_dates
-from .output import WrittenParquetPath, OutputData, ExpectedOutput
+from .output import OutputData, ExpectedOutput
 from .paths import get_dt, get_root_path
 from .types import SinkMarkerPath, SinkOutputRootPath
 from .writer import DataWriter

--- a/packages/op-coreutils/src/op_coreutils/request.py
+++ b/packages/op-coreutils/src/op_coreutils/request.py
@@ -40,7 +40,7 @@ def get_data(session: requests.Session, url: str, headers: dict[str, str] | None
     resp.raise_for_status()
 
     if resp.status_code != 200:
-        raise Exception(f"status={resp.status}, url={url!r}")
+        raise Exception(f"status={resp.status_code}, url={url!r}")
 
     log.info(f"Fetched from {url}: {time.time() - start:.2f} seconds")
     return resp.json()

--- a/packages/op-coreutils/src/op_coreutils/request.py
+++ b/packages/op-coreutils/src/op_coreutils/request.py
@@ -1,5 +1,8 @@
-import urllib3
+import time
 from urllib3.util.retry import Retry
+
+import requests
+from requests.adapters import HTTPAdapter
 
 from op_coreutils.logger import structlog
 
@@ -13,7 +16,31 @@ DEFAULT_RETRY_STRATEGY = Retry(
 )
 
 
-def new_session():
-    http = urllib3.PoolManager(retries=DEFAULT_RETRY_STRATEGY)
+def new_session() -> requests.Session:
+    session = requests.Session()
+    adapter = HTTPAdapter(max_retries=DEFAULT_RETRY_STRATEGY)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
 
-    return http
+    return session
+
+
+def get_data(session: requests.Session, url: str, headers: dict[str, str] | None = None):
+    """Helper function to reuse an existing HTTP session to fetch data from a URL.
+
+    - Reports timing.
+    - Raises for HTTP error status codes (>400) and checks for 200 status code.
+    """
+    start = time.time()
+
+    headers = headers or {"Content-Type": "application/json"}
+
+    resp = session.request(method="GET", url=url, headers=headers)
+
+    resp.raise_for_status()
+
+    if resp.status_code != 200:
+        raise Exception(f"status={resp.status}, url={url!r}")
+
+    log.info(f"Fetched from {url}: {time.time() - start:.2f} seconds")
+    return resp.json()

--- a/packages/op-datasets/src/op_datasets/etl/ingestion/main.py
+++ b/packages/op-datasets/src/op_datasets/etl/ingestion/main.py
@@ -5,7 +5,6 @@ from op_coreutils.logger import bind_contextvars, clear_contextvars, human_inter
 from op_coreutils.partitioned import (
     DataLocation,
     OutputData,
-    SinkOutputRootPath,
 )
 
 from op_datasets.schemas import ONCHAIN_CURRENT_VERSION
@@ -169,7 +168,6 @@ def auditor(task: IngestionTask):
         task.store_output(
             OutputData(
                 dataframe=task.input_dataframes[name],
-                root_path=SinkOutputRootPath(f"{dataset.versioned_location}"),
                 dataset_name=name,
                 default_partition=default_partition,
             )
@@ -177,10 +175,7 @@ def auditor(task: IngestionTask):
 
 
 def writer(task: IngestionTask):
-    task.data_writer.write_all(
-        outputs=task.output_dataframes,
-        basename=task.block_batch.construct_parquet_filename(),
-    )
+    task.data_writer.write_all(outputs=task.output_dataframes)
 
 
 def checker(task: IngestionTask):

--- a/packages/op-datasets/src/op_datasets/etl/ingestion/task.py
+++ b/packages/op-datasets/src/op_datasets/etl/ingestion/task.py
@@ -11,6 +11,7 @@ from op_coreutils.partitioned import (
     OutputData,
     ExpectedOutput,
     SinkMarkerPath,
+    SinkOutputRootPath,
     DataWriter,
 )
 
@@ -76,6 +77,8 @@ class IngestionTask:
             # Construct expected output for the dataset.
             expected_outputs[name] = ExpectedOutput(
                 dataset_name=name,
+                root_path=SinkOutputRootPath(f"{dataset.versioned_location}"),
+                file_name=block_batch.construct_parquet_filename(),
                 marker_path=full_marker_path,
                 process_name="default",
                 additional_columns=dict(

--- a/packages/op-datasets/src/op_datasets/etl/intermediate/construct.py
+++ b/packages/op-datasets/src/op_datasets/etl/intermediate/construct.py
@@ -51,7 +51,7 @@ def construct_tasks(
 
                 expected_outputs[dataset_name] = ExpectedOutput(
                     dataset_name=dataset_name,
-                    root_path=SinkOutputRootPath(dataset_name),
+                    root_path=SinkOutputRootPath(f"intermediate/{dataset_name}"),
                     file_name="out.parquet",
                     marker_path=SinkMarkerPath(dataset_name),
                     process_name="default",

--- a/packages/op-datasets/src/op_datasets/etl/intermediate/construct.py
+++ b/packages/op-datasets/src/op_datasets/etl/intermediate/construct.py
@@ -6,6 +6,7 @@ from op_coreutils.partitioned import (
     DataReader,
     construct_input_batches,
     SinkMarkerPath,
+    SinkOutputRootPath,
     DataWriter,
     ExpectedOutput,
 )
@@ -47,8 +48,11 @@ def construct_tasks(
         for model in models:
             for dataset in REGISTERED_INTERMEDIATE_MODELS[model].expected_output_datasets:
                 dataset_name = f"{model}/{dataset}"
+
                 expected_outputs[dataset_name] = ExpectedOutput(
                     dataset_name=dataset_name,
+                    root_path=SinkOutputRootPath(dataset_name),
+                    file_name="out.parquet",
                     marker_path=SinkMarkerPath(dataset_name),
                     process_name="default",
                     additional_columns=dict(

--- a/packages/op-datasets/src/op_datasets/etl/intermediate/main.py
+++ b/packages/op-datasets/src/op_datasets/etl/intermediate/main.py
@@ -120,7 +120,6 @@ def writer(task: IntermediateModelsTask):
             relation_to_output(dataset_name, rel)
             for dataset_name, rel in task.output_duckdb_relations.items()
         ],
-        basename="blah.parquet",
     )
 
 

--- a/packages/op-datasets/src/op_datasets/etl/intermediate/testutils.py
+++ b/packages/op-datasets/src/op_datasets/etl/intermediate/testutils.py
@@ -170,6 +170,8 @@ class IntermediateModelTestBase(unittest.TestCase):
 
             arrow_table = rel.filter(block_filter).to_arrow_table()  # noqa: F841
             table_name = cls.input_table_name(dataset)
+
+            assert cls._duckdb_client is not None
             cls._duckdb_client.sql(f"CREATE TABLE {table_name} AS SELECT * FROM arrow_table")
 
             relations[dataset] = rel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ members = ["packages/op-datasets", "packages/op-coreutils"]
 [tool.mypy]
 files = ["src/**/*.py", "packages/**/*.py", "tests/**/*.py"]
 ignore_missing_imports = true
+check_untyped_defs = true
 
 [project.scripts]
 opdata = "op_analytics.cli.main:entrypoint"
@@ -46,6 +47,7 @@ dev-dependencies = [
     "sphinx>=8.0.2",
     "sphinxcontrib-typer>=0.5.0",
     "types-pyyaml>=6.0.12.20240917",
+    "types-requests>=2.32.0.20241016",
     "webdriver-manager>=4.0.2",
 ]
 

--- a/src/op_analytics/cli/subcommands/misc/docsgen/schema_mapping_docs.py
+++ b/src/op_analytics/cli/subcommands/misc/docsgen/schema_mapping_docs.py
@@ -13,7 +13,7 @@ from py_markdown_table.markdown_table import markdown_table
 EXCLUDED_COLS = {"ingestion_metadata"}
 
 
-def column_details_df(schema: CoreDataset) -> list[dict]:
+def column_details_df(schema: CoreDataset) -> pd.DataFrame:
     """Produces a list with display details for all of the columns in the schema."""
     return pd.DataFrame(
         [col.display_dict() for col in schema.columns if col.name not in EXCLUDED_COLS]
@@ -30,7 +30,9 @@ def generate():
     with open(output_path, "w") as fobj:
         fobj.write(template)
 
-        multiline = defaultdict(lambda: 30)
+        # Avoid having to codify the data columns in the multiline config dictionary
+        # by using a defaultdict.
+        multiline: dict[str, int] = defaultdict(lambda: 30)
 
         for name, dataset in ONCHAIN_CURRENT_VERSION.items():
             capitalized = name.capitalize()

--- a/src/op_analytics/cli/subcommands/pulls/app.py
+++ b/src/op_analytics/cli/subcommands/pulls/app.py
@@ -1,8 +1,10 @@
 import typer
 from op_coreutils.logger import structlog
-from op_analytics.cli.subcommands.pulls.l2beat import pull as l2beat_pull
-from op_analytics.cli.subcommands.pulls.defillama import pull_stables as dfl_pull_stables
-from op_analytics.cli.subcommands.pulls.agora import agora_pull
+
+from .agora import agora_pull
+from .defillama import pull_stables as dfl_pull_stables
+from .l2beat import pull as l2beat_pull
+from .github_analytics import pull as github_analytics_pull
 
 log = structlog.get_logger()
 
@@ -26,3 +28,9 @@ def dfl_stables():
 def agora():
     """Pull data from Agora."""
     agora_pull()
+
+
+@app.command()
+def github_analytics():
+    """Pull repo analytics data from GitHub."""
+    github_analytics_pull()

--- a/src/op_analytics/cli/subcommands/pulls/defillama.py
+++ b/src/op_analytics/cli/subcommands/pulls/defillama.py
@@ -1,16 +1,17 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Tuple
+
 import polars as pl
 from op_coreutils.bigquery.write import (
-    overwrite_unpartitioned_table,
     overwrite_partition_static,
+    overwrite_unpartitioned_table,
     upsert_partitioned_table,
 )
-from datetime import datetime, timedelta, timezone
 from op_coreutils.logger import structlog
-from op_coreutils.request import new_session, get_data
-from op_coreutils.time import now_date
+from op_coreutils.request import get_data, new_session
 from op_coreutils.threads import run_concurrently
+from op_coreutils.time import now_date
 
 log = structlog.get_logger()
 

--- a/src/op_analytics/cli/subcommands/pulls/defillama.py
+++ b/src/op_analytics/cli/subcommands/pulls/defillama.py
@@ -1,14 +1,16 @@
+# -*- coding: utf-8 -*-
 import time
+from typing import Dict, List, Optional, Tuple
 import polars as pl
 from op_coreutils.bigquery.write import (
-    most_recent_dates,
-    overwrite_partition_static,
-    overwrite_partitions_dynamic,
     overwrite_unpartitioned_table,
+    overwrite_partition_static,
+    upsert_partitioned_table,
 )
+from datetime import datetime, timedelta, timezone
 from op_coreutils.logger import structlog
 from op_coreutils.request import new_session
-from op_coreutils.time import dt_fromepoch, now_date
+from op_coreutils.time import now_date
 from op_coreutils.threads import run_concurrently
 
 log = structlog.get_logger()
@@ -22,50 +24,70 @@ BREAKDOWN_TABLE = "defillama_daily_stablecoins_breakdown"
 METADATA_TABLE = "defillama_stablecoins_metadata"
 
 
-def get_data(session, url):
+def get_data(session, url: str) -> Optional[dict]:
+    """
+    Fetches data from a given URL using the provided session.
+
+    Args:
+        session: The HTTP session for making requests.
+        url (str): The URL to fetch data from.
+
+    Returns:
+        Optional[dict]: The JSON response as a dictionary, or None if an error occurred.
+    """
     start = time.time()
-    resp = session.request(
-        method="GET",
-        url=url,
-        headers={"Content-Type": "application/json"},
-    ).json()
-    log.info(f"Fetched from {url}: {time.time() - start:.2f} seconds")
-    return resp
+    try:
+        response = session.get(url, headers={"Content-Type": "application/json"})
+        response.raise_for_status()
+        resp_json = response.json()
+        log.info(f"Fetched from {url}: {time.time() - start:.2f} seconds")
+        return resp_json
+    except Exception as e:
+        log.error(f"Failed to fetch data from {url}: {e}")
+        return None
 
 
-def process_breakdown_stables(data):
-    peg_type = data["pegType"]
-    balances = data["chainBalances"]
+def process_breakdown_stables(
+    data: dict, days: int = 30
+) -> Tuple[pl.DataFrame, Dict[str, Optional[str]]]:
+    """
+    Processes breakdown data for stablecoins, filtering for the most recent N days.
 
-    rows = []
+    Args:
+        data (dict): The breakdown data from the API.
+        days (int): The number of days to filter in the processed data.
+
+    Returns:
+        Tuple[pl.DataFrame, Dict[str, Optional[str]]]: A Polars DataFrame with breakdown data and metadata dictionary.
+    """
+    if data is None:
+        return pl.DataFrame(), {}
+
+    peg_type: str = data.get("pegType", "")
+    balances: Dict[str, dict] = data.get("chainBalances", {})
+
+    cutoff_date = datetime.now(timezone.utc) - timedelta(days=days)
+    rows: List[Dict[str, Optional[str]]] = []
+
     for chain, balance in balances.items():
-        tokens = balance["tokens"]
+        tokens = balance.get("tokens", [])
+        filtered_tokens = [
+            datapoint
+            for datapoint in tokens
+            if datetime.fromtimestamp(datapoint["date"], tz=timezone.utc) >= cutoff_date
+        ]
 
-        for datapoint in tokens:
-            row = {}
-            row["chain"] = chain
-            row["dt"] = dt_fromepoch(datapoint["date"])
-
-            try:
-                row["circulating"] = datapoint["circulating"][peg_type]
-            except KeyError:
-                row["circulating"] = None
-
-            try:
-                row["bridged_to"] = datapoint["bridgedTo"][peg_type]
-            except KeyError:
-                row["bridged_to"] = None
-
-            try:
-                row["minted"] = datapoint["minted"][peg_type]
-            except KeyError:
-                row["minted"] = None
-
-            try:
-                row["unreleased"] = datapoint["unreleased"][peg_type]
-            except KeyError:
-                row["unreleased"] = None
-
+        for datapoint in filtered_tokens:
+            row: Dict[str, Optional[str]] = {
+                "chain": chain,
+                "dt": datetime.fromtimestamp(
+                    datapoint["date"], tz=timezone.utc
+                ).strftime("%Y-%m-%d"),
+                "circulating": datapoint.get("circulating", {}).get(peg_type),
+                "bridged_to": datapoint.get("bridgedTo", {}).get(peg_type),
+                "minted": datapoint.get("minted", {}).get(peg_type),
+                "unreleased": datapoint.get("unreleased", {}).get(peg_type),
+            }
             rows.append(row)
 
     must_have_metadata_fields = [
@@ -88,60 +110,108 @@ def process_breakdown_stables(data):
         "price",
     ]
 
-    metadata = {}
-    for key in must_have_metadata_fields:
-        metadata[key] = data[key]
+    metadata: Dict[str, Optional[str]] = {
+        key: data.get(key) for key in must_have_metadata_fields + metadata_fields
+    }
 
-    for key in metadata_fields:
-        metadata[key] = data.get(key)
-
-    result = pl.DataFrame(rows, infer_schema_length=len(rows)).with_columns(
-        id=pl.lit(metadata["id"]),
-        name=pl.lit(metadata["name"]),
-        symbol=pl.lit(metadata["symbol"]),
+    result = (
+        pl.DataFrame(rows, infer_schema_length=len(rows)).with_columns(
+            id=pl.lit(metadata["id"]),
+            name=pl.lit(metadata["name"]),
+            symbol=pl.lit(metadata["symbol"]),
+        )
+        if rows
+        else pl.DataFrame()
     )
 
     return result, metadata
 
 
-def pull_stables():
-    """Pull stablecoin data from DeFiLlama.
+def pull_stables(
+    stablecoin_ids: Optional[List[str]] = None, days: int = 30
+) -> Dict[str, pl.DataFrame]:
+    """
+    Pulls and processes stablecoin data from DeFiLlama.
 
-    - Fetch the stablecoins summary endpoint.
-    - For each stablecoin, fetch the detailed breakdown data.
-    - Write all results to BigQuery.
+    Args:
+        stablecoin_ids (Optional[List[str]]): List of stablecoin IDs to process. Defaults to None (process all).
+        days (int): Number of days of data to retrieve. Defaults to 30.
+
+    Returns:
+        Dict[str, pl.DataFrame]: A dictionary containing metadata and breakdown DataFrames.
     """
     session = new_session()
     summary = get_data(session, SUMMARY_ENDPOINT)
+    if summary is None:
+        log.error("Failed to fetch summary data.")
+        return {"metadata": pl.DataFrame(), "breakdown": pl.DataFrame()}
 
-    urls = {}
-    for stablecoin in summary["peggedAssets"]:
-        stablecoin_id = stablecoin["id"]
-        urls[stablecoin_id] = BREAKDOWN_ENDPOINT.format(id=stablecoin_id)
+    all_stablecoin_ids = [asset["id"] for asset in summary.get("peggedAssets", [])]
+    if stablecoin_ids is not None:
+        # Filter only the stablecoin IDs provided
+        stablecoin_ids = [id_ for id_ in stablecoin_ids if id_ in all_stablecoin_ids]
+        if not stablecoin_ids:
+            log.error("No valid stablecoin IDs provided.")
+            return {"metadata": pl.DataFrame(), "breakdown": pl.DataFrame()}
+    else:
+        stablecoin_ids = all_stablecoin_ids
 
-    stablecoin_data = run_concurrently(lambda x: get_data(session, x), urls, max_workers=4)
+    urls = {
+        stablecoin_id: BREAKDOWN_ENDPOINT.format(id=stablecoin_id)
+        for stablecoin_id in stablecoin_ids
+    }
 
-    breakdown_dfs = []
-    metadata_rows = []
-    for data in stablecoin_data.values():
-        breakdown_df, metadata = process_breakdown_stables(data)
-        breakdown_dfs.append(breakdown_df)
-        metadata_rows.append(metadata)
-
-    breakdown_df = pl.concat(breakdown_dfs, how="diagonal_relaxed")
-    metadata_df = pl.DataFrame(metadata_rows, infer_schema_length=len(metadata_rows))
-
-    # Write metadata to BQ
-    dt = now_date()
-    overwrite_unpartitioned_table(metadata_df, BQ_DATASET, f"{METADATA_TABLE}_latest")
-    overwrite_partition_static(metadata_df, dt, BQ_DATASET, f"{METADATA_TABLE}_history")
-
-    # Write breakdown to BQ. Only the most recent 7 days are inserted.
-    # Data in BQ older than 7 days is considered immutable.
-    overwrite_partitions_dynamic(
-        df=most_recent_dates(breakdown_df, n_dates=7),
-        dataset=BQ_DATASET,
-        table_name=f"{BREAKDOWN_TABLE}_history",
+    stablecoin_data = run_concurrently(
+        lambda x: get_data(session, x), urls, max_workers=4
     )
+
+    breakdown_dfs: List[pl.DataFrame] = []
+    metadata_rows: List[Dict[str, Optional[str]]] = []
+
+    for data in stablecoin_data.values():
+        if data:
+            breakdown_df, metadata = process_breakdown_stables(data, days=days)
+            if not breakdown_df.is_empty():
+                breakdown_dfs.append(breakdown_df)
+            if metadata:
+                metadata_rows.append(metadata)
+        else:
+            log.warning("Received empty data for a stablecoin.")
+
+    breakdown_df = (
+        pl.concat(breakdown_dfs, how="diagonal_relaxed")
+        if breakdown_dfs
+        else pl.DataFrame()
+    )
+    metadata_df = (
+        pl.DataFrame(metadata_rows, infer_schema_length=len(metadata_rows))
+        if metadata_rows
+        else pl.DataFrame()
+    )
+
+    dt = now_date()
+
+    if not metadata_df.is_empty():
+        overwrite_unpartitioned_table(
+            metadata_df, BQ_DATASET, f"{METADATA_TABLE}_latest"
+        )
+        overwrite_partition_static(
+            metadata_df,
+            partition_dt=dt,
+            dataset=BQ_DATASET,
+            table_name=f"{METADATA_TABLE}_history",
+        )
+
+    if not breakdown_df.is_empty():
+        dates = breakdown_df["dt"].unique().to_list()
+        for date_value in dates:
+            date_data = breakdown_df.filter(pl.col("dt") == date_value)
+            upsert_partitioned_table(
+                date_data,
+                dataset=BQ_DATASET,
+                table_name=f"{BREAKDOWN_TABLE}_history",
+                unique_keys=["dt", "id", "chain"],
+                partition_dt=date_value,
+            )
 
     return {"metadata": metadata_df, "breakdown": breakdown_df}

--- a/src/op_analytics/cli/subcommands/pulls/github_analytics.py
+++ b/src/op_analytics/cli/subcommands/pulls/github_analytics.py
@@ -1,0 +1,217 @@
+import os
+import requests
+from datetime import datetime
+
+import polars as pl
+from op_coreutils.bigquery.write import (
+    overwrite_partition_static,
+    overwrite_unpartitioned_table,
+    upsert_unpartitioned_table,
+)
+from op_coreutils.logger import structlog
+from op_coreutils.request import new_session, get_data
+from op_coreutils.time import now_date
+from op_coreutils.threads import run_concurrently
+from op_coreutils.env.vault import env_get
+
+log = structlog.get_logger()
+
+# GitHub API endpoint
+REPOS_BASE_URL = "https://api.github.com/repos/ethereum-optimism"
+
+# Repos to track
+REPOS = ["supersim"]
+
+# Dataset and Tables
+BQ_DATASET = "uploads_api"
+ANALYTICS_TABLE = "github_daily_analytics"
+REFERRERS_TABLE = "github_daily_referrers_snapshot"
+
+
+def pull():
+    session = new_session()
+
+    token = env_get("GITHUB_API_TOKEN")
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"token {token}",
+    }
+
+    # Fetch data for all repos.
+    repo_dfs = run_concurrently(
+        lambda repo: process_repo(session, headers, repo=repo),
+        targets=REPOS,
+        max_workers=3,
+    )
+
+    # Consolidate into one dataframe per table for all repos.
+    all_metrics = []
+    all_referrers = []
+    for referrers_df, metrics_df in repo_dfs.values():
+        all_metrics.append(metrics_df)
+        all_referrers.append(referrers_df)
+    all_metrics_df = pl.concat(all_metrics).select(
+        "date",
+        "repo_name",
+        "metric",
+        "value",
+    )
+    all_referrers_df = pl.concat(all_referrers).select(
+        "repo_name",
+        "referrer",
+        "views",
+        "unique_visitors",
+    )
+
+    # Write to BQ.
+    if os.environ.get("CREATE_TABLES") == "true":
+        # Use with care. Should only really be used the
+        # first time the table is created.
+        overwrite_unpartitioned_table(
+            df=all_metrics_df,
+            dataset=BQ_DATASET,
+            table_name=ANALYTICS_TABLE,
+        )
+    else:
+        upsert_unpartitioned_table(
+            df=all_metrics_df,
+            dataset=BQ_DATASET,
+            table_name=ANALYTICS_TABLE,
+            unique_keys=["date", "repo_name", "metric"],
+        )
+
+    current_date = now_date()
+    overwrite_partition_static(
+        df=all_referrers_df,
+        partition_dt=current_date,
+        dataset=BQ_DATASET,
+        table_name=REFERRERS_TABLE,
+    )
+
+
+def process_repo(session: requests.Session, headers: dict[str, str], repo: str):
+    views = get_data(
+        session=session,
+        url=REPOS_BASE_URL + f"/{repo}/traffic/views",
+        headers=headers,
+    )
+    clones = get_data(
+        session=session,
+        url=REPOS_BASE_URL + f"/{repo}/traffic/clones",
+        headers=headers,
+    )
+    forks = get_data(
+        session=session,
+        url=REPOS_BASE_URL + f"/{repo}/forks?sort=oldest",
+        headers=headers,
+    )
+    referrers = get_data(
+        session=session,
+        url=REPOS_BASE_URL + f"/{repo}/traffic/popular/referrers",
+        headers=headers,
+    )
+
+    views_df = process_views(views)
+    clones_df = process_clones(clones)
+    forks_df = process_forks(forks)
+    metrics_df = (
+        pl.concat([views_df, clones_df, forks_df]).sort("date").with_columns(repo_name=pl.lit(repo))
+    )
+
+    referrers_df = process_referrers(referrers).with_columns(repo_name=pl.lit(repo))
+
+    return referrers_df, metrics_df
+
+
+METRIC_SCHEMA = {
+    "date": pl.Date(),
+    "metric": pl.String(),
+    "value": pl.Int32(),
+}
+
+
+def process_views(views):
+    views_data = []
+    for item in views["views"]:
+        dateval = datetime.fromisoformat(item["timestamp"]).date()
+        views_data.append(
+            {
+                "date": dateval,
+                "metric": "views_total",
+                "value": item["count"],
+            }
+        )
+        views_data.append(
+            {
+                "date": dateval,
+                "metric": "views_unique",
+                "value": item["uniques"],
+            }
+        )
+
+    return pl.DataFrame(views_data, schema=METRIC_SCHEMA)
+
+
+def process_clones(clones):
+    clones_data = []
+    for item in clones["clones"]:
+        dateval = datetime.fromisoformat(item["timestamp"]).date()
+        clones_data.append(
+            {
+                "date": dateval,
+                "metric": "clones_total",
+                "value": item["count"],
+            }
+        )
+        clones_data.append(
+            {
+                "date": dateval,
+                "metric": "clones_unique",
+                "value": item["uniques"],
+            }
+        )
+
+    return pl.DataFrame(clones_data, schema=METRIC_SCHEMA)
+
+
+def process_forks(forks):
+    forks_data = []
+    for item in forks:
+        forks_data.append(
+            {
+                "date": datetime.fromisoformat(item["created_at"]).date(),
+            }
+        )
+
+    forks_df = pl.DataFrame(forks_data, schema={"date": pl.Date()})
+    forks_count_df = (
+        forks_df.group_by("date")
+        .agg(pl.count().alias("value"))
+        .with_columns(metric=pl.lit("forks_total"))
+    )
+    return forks_count_df.select(
+        pl.col("date"),
+        pl.col("metric"),
+        pl.col("value").cast(pl.Int32()),
+    )
+
+
+def process_referrers(referrers):
+    referrers_data = []
+    for item in referrers:
+        referrers_data.append(
+            {
+                "referrer": item["referrer"],
+                "views": item["count"],
+                "unique_visitors": item["uniques"],
+            }
+        )
+
+    return pl.DataFrame(
+        referrers_data,
+        schema={
+            "referrer": pl.String(),
+            "views": pl.Int32(),
+            "unique_visitors": pl.Int32(),
+        },
+    )

--- a/src/op_analytics/cli/subcommands/pulls/l2beat.py
+++ b/src/op_analytics/cli/subcommands/pulls/l2beat.py
@@ -1,4 +1,3 @@
-import time
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -11,7 +10,7 @@ from op_coreutils.bigquery.write import (
     overwrite_unpartitioned_table,
 )
 from op_coreutils.logger import structlog
-from op_coreutils.request import new_session
+from op_coreutils.request import new_session, get_data
 from op_coreutils.threads import run_concurrently
 from op_coreutils.time import now_date
 
@@ -44,18 +43,6 @@ ACTIVITY_SCHEMA: dict[str, type[pl.DataType]] = {
 # Use "max" for backfill
 # Otherwise use 30d to get 6hr data intervals
 ACTIVITY_QUERY_RANGE = "30d"
-
-
-def get_data(session, url):
-    """Helper function to reuse an existing HTTP session to fetch data from a URL."""
-    start = time.time()
-    resp = session.request(
-        method="GET",
-        url=url,
-        headers={"Content-Type": "application/json"},
-    ).json()
-    log.info(f"Fetched from {url}: {time.time() - start:.2f} seconds")
-    return resp
 
 
 @dataclass(frozen=True)

--- a/tests/op_analytics/cli/pulls/defillama/mockdata/stablecoin_test_cases.json
+++ b/tests/op_analytics/cli/pulls/defillama/mockdata/stablecoin_test_cases.json
@@ -1,0 +1,68 @@
+{
+    "test_cases": [
+        {
+            "description": "Test TerraClassicUSD Metadata",
+            "input": {
+                "id": "3",
+                "name": "TerraClassicUSD",
+                "address": null,
+                "symbol": "USTC",
+                "url": "https://www.terra.money/",
+                "pegType": "peggedUSD",
+                "pegMechanism": "algorithmic"
+            },
+            "expected": {
+                "id": "3",
+                "name": "TerraClassicUSD",
+                "address": null,
+                "symbol": "USTC",
+                "url": "https://www.terra.money/",
+                "pegType": "peggedUSD",
+                "pegMechanism": "algorithmic"
+            }
+        },
+        {
+            "description": "Test Token Data on Optimism Chain",
+            "input": {
+                "chain": "Optimism",
+                "tokens": [
+                    {
+                        "date": 1654214400,
+                        "circulating": {
+                            "peggedUSD": 100326
+                        },
+                        "bridgedTo": {
+                            "peggedUSD": 100326,
+                            "bridges": {
+                                "synapse": {
+                                    "amount": 100326,
+                                    "source": "Terra"
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            "expected": {
+                "chain": "Optimism",
+                "tokens": [
+                    {
+                        "date": 1654214400,
+                        "circulating": {
+                            "peggedUSD": 100326
+                        },
+                        "bridgedTo": {
+                            "peggedUSD": 100326,
+                            "bridges": {
+                                "synapse": {
+                                    "amount": 100326,
+                                    "source": "Terra"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tests/op_analytics/cli/pulls/defillama/test_defillama.py
+++ b/tests/op_analytics/cli/pulls/defillama/test_defillama.py
@@ -7,9 +7,7 @@ import pytest
 from unittest.mock import patch
 from op_analytics.cli.subcommands.pulls import defillama
 
-
 TESTDATA = InputTestData.at(__file__)
-
 
 # Sample data resembling the API response
 current_timestamp = int(datetime.now(timezone.utc).timestamp())
@@ -77,7 +75,7 @@ def test_process_breakdown_stables(mock_sample_data):
     assert result_df["unreleased"][0] == 0
 
 
-@patch("op_analytics.cli.subcommands.pulls.defillama.get_data")
+@patch("op_analytics.cli.subcommands.pulls.defillama.get_data")  # Correct mock path
 @patch("op_analytics.cli.subcommands.pulls.defillama.overwrite_unpartitioned_table")
 @patch("op_analytics.cli.subcommands.pulls.defillama.overwrite_partition_static")
 @patch("op_analytics.cli.subcommands.pulls.defillama.upsert_partitioned_table")

--- a/tests/op_analytics/cli/pulls/defillama/test_defillama.py
+++ b/tests/op_analytics/cli/pulls/defillama/test_defillama.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
-from op_coreutils.testutils.inputdata import InputTestData
-from unittest.mock import MagicMock
-import polars as pl
 from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import polars as pl
 import pytest
-from unittest.mock import patch
+from op_coreutils.testutils.inputdata import InputTestData
+
 from op_analytics.cli.subcommands.pulls import defillama
 
 TESTDATA = InputTestData.at(__file__)

--- a/tests/op_analytics/cli/pulls/defillama/test_defillama.py
+++ b/tests/op_analytics/cli/pulls/defillama/test_defillama.py
@@ -1,149 +1,133 @@
-import json
-
+# -*- coding: utf-8 -*-
 from op_coreutils.testutils.inputdata import InputTestData
-
+from unittest.mock import MagicMock
+import polars as pl
+from datetime import datetime, timezone
+import pytest
+from unittest.mock import patch
 from op_analytics.cli.subcommands.pulls import defillama
+
 
 TESTDATA = InputTestData.at(__file__)
 
 
-def test_process_breakdown_data():
-    with open(TESTDATA.path("mockdata/stablecoin_tether.json"), "r") as fobj:
-        data = json.load(fobj)
+# Sample data resembling the API response
+current_timestamp = int(datetime.now(timezone.utc).timestamp())
 
-    dataframe, metadata = defillama.process_breakdown_stables(data)
+sample_data = {
+    "pegType": "peggedUSD",
+    "chainBalances": {
+        "Ethereum": {
+            "tokens": [
+                {
+                    "date": current_timestamp,
+                    "circulating": {"peggedUSD": 1000000},
+                    "bridgedTo": {"peggedUSD": 200000},
+                    "minted": {"peggedUSD": 1200000},
+                    "unreleased": {"peggedUSD": 0},
+                },
+                {
+                    "date": current_timestamp - 86400 * 2,  # 2 days ago
+                    "circulating": {"peggedUSD": 900000},
+                    "bridgedTo": {"peggedUSD": 180000},
+                    "minted": {"peggedUSD": 1080000},
+                    "unreleased": {"peggedUSD": 0},
+                },
+            ]
+        }
+    },
+    "id": "sample-stablecoin",
+    "name": "Sample Stablecoin",
+    "address": "0xSampleAddress",
+    "symbol": "SSC",
+    "url": "https://samplestablecoin.com",
+    "pegMechanism": "fiat-backed",
+    "description": "A sample stablecoin for testing.",
+    "mintRedeemDescription": "Mint and redeem instructions.",
+    "onCoinGecko": True,
+    "gecko_id": "sample-stablecoin",
+    "cmcId": "12345",
+    "priceSource": "coingecko",
+    "twitter": "@samplestablecoin",
+    "price": 1.00,
+}
 
-    expected_metadata = {
-        "id": "1",
-        "name": "Tether",
-        "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-        "symbol": "USDT",
-        "url": "https://tether.to/",
-        "pegType": "peggedUSD",
-        "pegMechanism": "fiat-backed",
-        "description": "Launched in 2014, Tether tokens pioneered the stablecoin model. Tether tokens are pegged to real-world currencies on a 1-to-1 basis. This offers traders, merchants and funds a low volatility solution when exiting positions in the market.",
-        "mintRedeemDescription": "Tether customers who have undergone a verification process can exchange USD for USDT and redeem USDT for USD.",
-        "onCoinGecko": "true",
-        "gecko_id": "tether",
-        "cmcId": "825",
-        "priceSource": "defillama",
-        "twitter": "https://twitter.com/Tether_to",
-        "price": 0.999751,
-    }
-    assert metadata == expected_metadata
 
-    actual_rows = dataframe.to_dicts()[:10]
-    expected_rows = [
+@pytest.fixture
+def mock_sample_data():
+    return sample_data
+
+
+def test_process_breakdown_stables(mock_sample_data):
+    # Test with default days=30
+    result_df, metadata = defillama.process_breakdown_stables(mock_sample_data)
+    assert isinstance(result_df, pl.DataFrame)
+    assert len(result_df) == 2  # Two data points within 30 days
+    assert metadata["id"] == "sample-stablecoin"
+    assert metadata["name"] == "Sample Stablecoin"
+
+    # Test filtering with days=1
+    result_df_recent, _ = defillama.process_breakdown_stables(mock_sample_data, days=1)
+    assert len(result_df_recent) == 1  # Only the most recent data point
+
+    # Check data correctness
+    assert result_df["circulating"][0] == 1000000
+    assert result_df["bridged_to"][0] == 200000
+    assert result_df["minted"][0] == 1200000
+    assert result_df["unreleased"][0] == 0
+
+
+@patch("op_analytics.cli.subcommands.pulls.defillama.get_data")
+@patch("op_analytics.cli.subcommands.pulls.defillama.overwrite_unpartitioned_table")
+@patch("op_analytics.cli.subcommands.pulls.defillama.overwrite_partition_static")
+@patch("op_analytics.cli.subcommands.pulls.defillama.upsert_partitioned_table")
+@patch("op_analytics.cli.subcommands.pulls.defillama.new_session")
+def test_pull_stables(
+    mock_new_session,
+    mock_upsert_partitioned_table,
+    mock_overwrite_partition_static,
+    mock_overwrite_unpartitioned_table,
+    mock_get_data,
+    mock_sample_data,
+):
+    # Mock the session
+    mock_session = MagicMock()
+    mock_new_session.return_value = mock_session
+
+    # Mock get_data to return sample summary and sample data
+    mock_get_data.side_effect = [
         {
-            "chain": "Optimism",
-            "dt": "2022-05-12",
-            "circulating": 19021887.0,
-            "bridged_to": 19021887.0,
-            "minted": None,
-            "unreleased": None,
-            "id": "1",
-            "name": "Tether",
-            "symbol": "USDT",
+            "peggedAssets": [
+                {"id": "sample-stablecoin", "name": "Sample Stablecoin"},
+                {"id": "another-stablecoin", "name": "Another Stablecoin"},
+            ]
         },
-        {
-            "chain": "Optimism",
-            "dt": "2022-05-13",
-            "circulating": 19021887.0,
-            "bridged_to": 19021887.0,
-            "minted": None,
-            "unreleased": None,
-            "id": "1",
-            "name": "Tether",
-            "symbol": "USDT",
-        },
-        {
-            "chain": "Optimism",
-            "dt": "2022-05-14",
-            "circulating": 19021906.0,
-            "bridged_to": 19021906.0,
-            "minted": None,
-            "unreleased": None,
-            "id": "1",
-            "name": "Tether",
-            "symbol": "USDT",
-        },
-        {
-            "chain": "Optimism",
-            "dt": "2022-05-15",
-            "circulating": 19023188.0,
-            "bridged_to": 19023188.0,
-            "minted": None,
-            "unreleased": None,
-            "id": "1",
-            "name": "Tether",
-            "symbol": "USDT",
-        },
-        {
-            "chain": "Optimism",
-            "dt": "2022-05-16",
-            "circulating": 18844204.0,
-            "bridged_to": 18844204.0,
-            "minted": None,
-            "unreleased": None,
-            "id": "1",
-            "name": "Tether",
-            "symbol": "USDT",
-        },
-        {
-            "chain": "Optimism",
-            "dt": "2022-05-17",
-            "circulating": 18850486.0,
-            "bridged_to": 18850486.0,
-            "minted": None,
-            "unreleased": None,
-            "id": "1",
-            "name": "Tether",
-            "symbol": "USDT",
-        },
-        {
-            "chain": "Optimism",
-            "dt": "2022-05-18",
-            "circulating": 18875986.0,
-            "bridged_to": 18875986.0,
-            "minted": None,
-            "unreleased": None,
-            "id": "1",
-            "name": "Tether",
-            "symbol": "USDT",
-        },
-        {
-            "chain": "Optimism",
-            "dt": "2022-05-19",
-            "circulating": 19207042.0,
-            "bridged_to": 19207042.0,
-            "minted": None,
-            "unreleased": None,
-            "id": "1",
-            "name": "Tether",
-            "symbol": "USDT",
-        },
-        {
-            "chain": "Optimism",
-            "dt": "2022-05-20",
-            "circulating": 19358232.0,
-            "bridged_to": 19358232.0,
-            "minted": None,
-            "unreleased": None,
-            "id": "1",
-            "name": "Tether",
-            "symbol": "USDT",
-        },
-        {
-            "chain": "Optimism",
-            "dt": "2022-05-21",
-            "circulating": 19368126.0,
-            "bridged_to": 19368126.0,
-            "minted": None,
-            "unreleased": None,
-            "id": "1",
-            "name": "Tether",
-            "symbol": "USDT",
-        },
+        mock_sample_data,  # For the stablecoin breakdown
     ]
 
-    assert actual_rows == expected_rows
+    # Call the function under test
+    result = defillama.pull_stables(stablecoin_ids=["sample-stablecoin"], days=30)
+
+    # Assertions
+    assert "metadata" in result
+    assert "breakdown" in result
+    assert isinstance(result["metadata"], pl.DataFrame)
+    assert isinstance(result["breakdown"], pl.DataFrame)
+    assert len(result["metadata"]) == 1
+    assert len(result["breakdown"]) == 2
+
+    # Check that BigQuery functions were called
+    assert mock_overwrite_unpartitioned_table.called
+    assert mock_overwrite_partition_static.called
+    assert mock_upsert_partitioned_table.called
+
+    # Verify that get_data was called twice (summary and breakdown)
+    assert mock_get_data.call_count == 2
+
+    # Check that upsert_partitioned_table was called with correct parameters
+    args, kwargs = mock_upsert_partitioned_table.call_args
+    assert "dataset" in kwargs
+    assert "table_name" in kwargs
+    assert "unique_keys" in kwargs
+    assert "partition_dt" in kwargs
+    assert kwargs["unique_keys"] == ["dt", "id", "chain"]

--- a/tests/op_analytics/cli/pulls/defillama/test_defillama.py
+++ b/tests/op_analytics/cli/pulls/defillama/test_defillama.py
@@ -76,17 +76,17 @@ def test_process_breakdown_stables(mock_sample_data):
     assert result_df["unreleased"][0] == 0
 
 
-@patch("op_analytics.cli.subcommands.pulls.defillama.get_data")  # Correct mock path
-@patch("op_analytics.cli.subcommands.pulls.defillama.overwrite_unpartitioned_table")
-@patch("op_analytics.cli.subcommands.pulls.defillama.overwrite_partition_static")
-@patch("op_analytics.cli.subcommands.pulls.defillama.upsert_partitioned_table")
 @patch("op_analytics.cli.subcommands.pulls.defillama.new_session")
+@patch("op_analytics.cli.subcommands.pulls.defillama.upsert_partitioned_table")
+@patch("op_analytics.cli.subcommands.pulls.defillama.overwrite_partition_static")
+@patch("op_analytics.cli.subcommands.pulls.defillama.overwrite_unpartitioned_table")
+@patch("op_analytics.cli.subcommands.pulls.defillama.get_data")
 def test_pull_stables(
-    mock_new_session,
-    mock_upsert_partitioned_table,
-    mock_overwrite_partition_static,
-    mock_overwrite_unpartitioned_table,
     mock_get_data,
+    mock_overwrite_unpartitioned_table,
+    mock_overwrite_partition_static,
+    mock_upsert_partitioned_table,
+    mock_new_session,
     mock_sample_data,
 ):
     # Mock the session

--- a/tests/op_coreutils/partitioned/test_marker.py
+++ b/tests/op_coreutils/partitioned/test_marker.py
@@ -5,6 +5,7 @@ from op_coreutils.partitioned.location import DataLocation
 from op_coreutils.partitioned.marker import Marker, marker_exists, markers_for_dates
 from op_coreutils.partitioned.output import ExpectedOutput, KeyValue, OutputPartMeta
 from op_coreutils.partitioned.writer import write_marker
+from op_coreutils.partitioned.types import SinkMarkerPath, SinkOutputRootPath
 from op_coreutils.duckdb_local import run_query
 from op_coreutils.time import now
 
@@ -32,9 +33,11 @@ def test_marker():
             ),
         ],
         expected_output=ExpectedOutput(
-            marker_path="markers/ingestion/blocks_v1/chain=DUMMYCHAIN/000011540000.json",
+            marker_path=SinkMarkerPath(
+                "markers/ingestion/blocks_v1/chain=DUMMYCHAIN/000011540000.json"
+            ),
             dataset_name="blocks",
-            root_path="ingestion/blocks_v1",
+            root_path=SinkOutputRootPath("ingestion/blocks_v1"),
             file_name="000011540000.parquet",
             process_name="default",
             additional_columns={"num_blocks": 20000, "min_block": 11540000, "max_block": 11560000},

--- a/tests/op_coreutils/partitioned/test_marker.py
+++ b/tests/op_coreutils/partitioned/test_marker.py
@@ -3,7 +3,7 @@ import pyarrow as pa
 
 from op_coreutils.partitioned.location import DataLocation
 from op_coreutils.partitioned.marker import Marker, marker_exists, markers_for_dates
-from op_coreutils.partitioned.output import WrittenParquetPath, KeyValue
+from op_coreutils.partitioned.output import ExpectedOutput, KeyValue, OutputPartMeta
 from op_coreutils.partitioned.writer import write_marker
 from op_coreutils.duckdb_local import run_query
 from op_coreutils.time import now
@@ -15,22 +15,15 @@ def test_marker():
     run_query(f"DELETE FROM etl_monitor.{MARKERS_TABLE} WHERE chain = 'DUMMYCHAIN'")
 
     marker = Marker(
-        marker_path="markers/ingestion/blocks_v1/chain=DUMMYCHAIN/000011540000.json",
-        dataset_name="blocks",
-        root_path="ingestion/blocks_v1",
-        data_paths=[
-            WrittenParquetPath(
-                root="ingestion/blocks_v1",
-                basename="000011540000.parquet",
+        written_parts=[
+            OutputPartMeta(
                 partitions=[
                     KeyValue(key="chain", value="DUMMYCHAIN"),
                     KeyValue(key="dt", value="2024-10-25"),
                 ],
                 row_count=5045,
             ),
-            WrittenParquetPath(
-                root="ingestion/blocks_v1",
-                basename="000011540000.parquet",
+            OutputPartMeta(
                 partitions=[
                     KeyValue(key="chain", value="DUMMYCHAIN"),
                     KeyValue(key="dt", value="2024-10-26"),
@@ -38,15 +31,21 @@ def test_marker():
                 row_count=14955,
             ),
         ],
-        process_name="default",
-        additional_columns={"num_blocks": 20000, "min_block": 11540000, "max_block": 11560000},
-        additional_columns_schema=[
-            pa.field("chain", pa.string()),
-            pa.field("dt", pa.date32()),
-            pa.field("num_blocks", pa.int32()),
-            pa.field("min_block", pa.int64()),
-            pa.field("max_block", pa.int64()),
-        ],
+        expected_output=ExpectedOutput(
+            marker_path="markers/ingestion/blocks_v1/chain=DUMMYCHAIN/000011540000.json",
+            dataset_name="blocks",
+            root_path="ingestion/blocks_v1",
+            file_name="000011540000.parquet",
+            process_name="default",
+            additional_columns={"num_blocks": 20000, "min_block": 11540000, "max_block": 11560000},
+            additional_columns_schema=[
+                pa.field("chain", pa.string()),
+                pa.field("dt", pa.date32()),
+                pa.field("num_blocks", pa.int32()),
+                pa.field("min_block", pa.int64()),
+                pa.field("max_block", pa.int64()),
+            ],
+        ),
     )
 
     initially_exists = marker_exists(

--- a/tests/op_datasets/etl/intermediate/models/test_daily_address_summary.py
+++ b/tests/op_datasets/etl/intermediate/models/test_daily_address_summary.py
@@ -28,6 +28,8 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
     _enable_fetching = False
 
     def test_system_address_not_included(self):
+        assert self._duckdb_client is not None
+
         ans = self._duckdb_client.sql(f"""
         SELECT * FROM daily_address_summary_v1 WHERE address = '{SYSTEM_ADDRESS}'
         """)
@@ -35,6 +37,8 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
         assert len(ans) == 0
 
     def test_uniqueness(self):
+        assert self._duckdb_client is not None
+
         unique_count = self._duckdb_client.sql("""
         SELECT COUNT(*) FROM (
             SELECT DISTINCT address, chain_id, dt FROM daily_address_summary_v1
@@ -44,13 +48,15 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
         SELECT COUNT(*) FROM daily_address_summary_v1
         """)
 
-        unique_count_val = unique_count.fetchone()[0]
-        total_count_val = total_count.fetchone()[0]
+        unique_count_val = (unique_count.fetchone() or [None])[0]
+        total_count_val = (total_count.fetchone() or [None])[0]
 
         assert unique_count_val == 785
         assert unique_count_val == total_count_val
 
     def test_model_schema(self):
+        assert self._duckdb_client is not None
+
         schema = (
             self._duckdb_client.sql("DESCRIBE daily_address_summary_v1")
             .pl()
@@ -103,6 +109,8 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
         }
 
     def test_single_txs_output(self):
+        assert self._duckdb_client is not None
+
         # Transaction that is relevant for this test:
         # https://optimistic.etherscan.io/tx/0x2ab7a335f3ecc0236ac9fc0c4832f4500d299ee40abf99e5609fa16309f82763
 
@@ -190,6 +198,8 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
         )
 
     def test_multiple_txs_output(self):
+        assert self._duckdb_client is not None
+
         # Transactions that are relevant for this test:
         # https://optimistic.etherscan.io/tx/0x0c8c81cc9a97f4d66f4f78ef2bbb5a64c23358db2c4ba6ad35e338f2d2fa3535
         # https://optimistic.etherscan.io/tx/0x8aa91fc3fb1c11cd4aba16130697a1fa52fd74ae7ee9f23627b6b8b42fec0a34
@@ -259,6 +269,8 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
         )
 
     def test_overall_totals(self):
+        assert self._duckdb_client is not None
+
         actual = (
             self._duckdb_client.sql("SELECT SUM(total_txs) FROM daily_address_summary_v1")
             .pl()
@@ -267,6 +279,8 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
         assert actual == [{"sum(total_txs)": Decimal("2397")}]
 
     def test_consistency(self):
+        assert self._duckdb_client is not None
+
         actual = (
             self._duckdb_client.sql("""
             WITH checks AS (

--- a/uv.lock
+++ b/uv.lock
@@ -1531,6 +1531,7 @@ dev = [
     { name = "sphinx" },
     { name = "sphinxcontrib-typer" },
     { name = "types-pyyaml" },
+    { name = "types-requests" },
     { name = "webdriver-manager" },
 ]
 
@@ -1563,6 +1564,7 @@ dev = [
     { name = "sphinx", specifier = ">=8.0.2" },
     { name = "sphinxcontrib-typer", specifier = ">=0.5.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20240917" },
+    { name = "types-requests", specifier = ">=2.32.0.20241016" },
     { name = "webdriver-manager", specifier = ">=4.0.2" },
 ]
 
@@ -2719,6 +2721,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/7d/a95df0a11f95c8f48d7683f03e4aed1a2c0fc73e9de15cca4d38034bea1a/types-PyYAML-6.0.12.20240917.tar.gz", hash = "sha256:d1405a86f9576682234ef83bcb4e6fff7c9305c8b1fbad5e0bcd4f7dbdc9c587", size = 12381 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/2c/c1d81d680997d24b0542aa336f0a65bd7835e5224b7670f33a7d617da379/types_PyYAML-6.0.12.20240917-py3-none-any.whl", hash = "sha256:392b267f1c0fe6022952462bf5d6523f31e37f6cea49b14cee7ad634b6301570", size = 15264 },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.32.0.20241016"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/3c/4f2a430c01a22abd49a583b6b944173e39e7d01b688190a5618bd59a2e22/types-requests-2.32.0.20241016.tar.gz", hash = "sha256:0d9cad2f27515d0e3e3da7134a1b6f28fb97129d86b867f24d9c726452634d95", size = 18065 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/01/485b3026ff90e5190b5e24f1711522e06c79f4a56c8f4b95848ac072e20f/types_requests-2.32.0.20241016-py3-none-any.whl", hash = "sha256:4195d62d6d3e043a4eaaf08ff8a62184584d2e8684e9d2aa178c7915a7da3747", size = 15836 },
 ]
 
 [[package]]


### PR DESCRIPTION
**Description**

Updated `defillama.py` to align with the new `write.py` functionality and resolve #[887](https://github.com/ethereum-optimism/op-analytics/issues/887)

Key changes:

- **Filtered API Results**: Modified data processing to only include the most recent N days, preventing daily rewrites of the entire history.
- **Selective Stablecoin Pull**: Added a `stablecoin_ids` parameter to `pull_stables`, allowing selective data retrieval and backfilling for specific stablecoins.
- **BigQuery Upsert Operations**: Replaced previous write operations with upsert functions (`overwrite_unpartitioned_table`, `overwrite_partition_static`, `upsert_partitioned_table`) to update BigQuery partitions without overwriting existing data.

**Tests**

Updated `test_defillama.py`:

- **Adjusted Mocks**: Updated mocked functions to match the new function names and signatures. Previously the mock data included an entire defillama response .csv which was multiple MBs
- **Verified Function Calls**: Ensured correct parameters are passed to the BigQuery functions, including `partition_dt` and `unique_keys`.
- **Validated Data Processing**: Confirmed that data filtering and processing work as expected with the new code through updated assertions.