### PR TITLE
All my modifications after very thorough review of Defillama stablecoins data pull

### DIFF
--- a/.github/workflows/uploads_api_daily.yml
+++ b/.github/workflows/uploads_api_daily.yml
@@ -23,6 +23,6 @@ jobs:
         env:
           OP_ANALYTICS_VAULT: ${{ secrets.OP_ANALYTICS_VAULT }}
       - name: DefiLlama
-        run: OPLABS_ENV=prod uv run opdata pulls dfl_stables
+        run: OPLABS_ENV=prod uv run opdata pulls defillama_stablecoins
         env:
           OP_ANALYTICS_VAULT: ${{ secrets.OP_ANALYTICS_VAULT }}

--- a/packages/op-coreutils/src/op_coreutils/bigquery/write.py
+++ b/packages/op-coreutils/src/op_coreutils/bigquery/write.py
@@ -1,6 +1,7 @@
 import io
+from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
-from typing import List
+from typing import Generator
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -153,25 +154,10 @@ def overwrite_partitions_dynamic(
         expiration_days (int, optional): If provided sets the expiration time of the table.
     """
 
-    # Ensure "dt" is a DateTime
-    if df["dt"].dtype == pl.String:
-        df = df.with_columns(dt=pl.col("dt").str.strptime(pl.Datetime, "%Y-%m-%d"))
-
-    partitions = df["dt"].unique().sort().to_list()
-
-    log.info(f"Writing {len(partitions)} partitions to BQ [{partitions[0]} ... {partitions[-1]}]")
-
-    if len(partitions) > 10:
-        raise OPLabsBigQueryError(
-            "Dynamic Partition Overwrite detected more than 10 partitions. Aborting."
-        )
-
-    for date_partition in partitions:
-        part_df = df.filter(pl.col("dt") == date_partition)
-        date_suffix = date_partition.strftime("%Y%m%d")
+    for date_part in breakout_partitioned_df(df):
         _write_df_to_bq(
-            part_df,
-            destination=f"{dataset}.{table_name}${date_suffix}",
+            date_part.date_df,
+            destination=f"{dataset}.{table_name}${date_part.date_suffix}",
             job_config=bigquery.LoadJobConfig(
                 source_format=bigquery.SourceFormat.PARQUET,
                 write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
@@ -212,6 +198,40 @@ def overwrite_partition_static(
     )
 
 
+@dataclass
+class DatePart:
+    date_df: pl.DataFrame
+    date_suffix: str
+
+
+def breakout_partitioned_df(df: pl.DataFrame) -> Generator[DatePart, None, None]:
+    """Checks that the dataframe is suitable for writing to a partitioned table.
+
+    Yields each date part along with the date part suffix for each date present in
+    the data.
+    """
+
+    # Ensure "dt" is a DateTime
+    if df["dt"].dtype == pl.String:
+        df = df.with_columns(dt=pl.col("dt").str.strptime(pl.Datetime, "%Y-%m-%d"))
+
+    partitions = df["dt"].unique().sort().to_list()
+
+    log.info(
+        f"Found {len(partitions)} partitions in dataframe [{partitions[0]} ... {partitions[-1]}]"
+    )
+
+    if len(partitions) > 10:
+        raise OPLabsBigQueryError(
+            "Dynamic Partition Overwrite detected more than 10 partitions. Aborting."
+        )
+
+    for date_partition in partitions:
+        part_df = df.filter(pl.col("dt") == date_partition)
+        date_suffix = date_partition.strftime("%Y%m%d")
+        yield DatePart(date_df=part_df, date_suffix=date_suffix)
+
+
 def _days_to_ms(days: int | None) -> int | None:
     if days is None:
         return None
@@ -247,7 +267,7 @@ def upsert_unpartitioned_table(
     df: pl.DataFrame,
     dataset: str,
     table_name: str,
-    unique_keys: List[str],
+    unique_keys: list[str],
 ):
     """Upsert data into an unpartitioned BigQuery table.
 
@@ -276,8 +296,7 @@ def upsert_partitioned_table(
     df: pl.DataFrame,
     dataset: str,
     table_name: str,
-    unique_keys: List[str],
-    partition_dt: str,
+    unique_keys: list[str],
 ):
     """Upsert data into a partitioned BigQuery table.
 
@@ -293,30 +312,32 @@ def upsert_partitioned_table(
     Raises:
         ValueError: If the DataFrame is empty or if unique_keys are not in the DataFrame.
     """
-    # Ensure 'dt' column is set to partition_dt
-    df = df.with_columns(dt=pl.lit(partition_dt).str.strptime(pl.Datetime, "%Y-%m-%d"))
-
-    _upsert_df_to_bq(
-        df=df,
-        dataset=dataset,
-        table_name=table_name,
-        unique_keys=unique_keys,
-    )
+    for date_part in breakout_partitioned_df(df):
+        _upsert_df_to_bq(
+            df=date_part.date_df,
+            dataset=dataset,
+            table_name=f"{table_name}${date_part.date_suffix}",
+            unique_keys=unique_keys,
+            # For a partitioned table the staging table name has to include the date suffix.
+            staging_table_name=f"{table_name}_{date_part.date_suffix}",
+        )
 
 
 def _upsert_df_to_bq(
     df: pl.DataFrame,
     dataset: str,
     table_name: str,
-    unique_keys: List[str],
+    unique_keys: list[str],
+    staging_table_name: str | None = None,
 ):
     """Helper function to upsert data into a BigQuery table.
 
     Args:
-        df (pl.DataFrame): The DataFrame to upsert.
-        dataset (str): The BigQuery dataset name.
-        table_name (str): The BigQuery table name.
-        unique_keys (List[str]): Columns that uniquely identify rows.
+        df: The DataFrame to upsert.
+        dataset: The BigQuery dataset name.
+        table_name: The BigQuery table name.
+        unique_keys: Columns that uniquely identify rows.
+        staging_table_name: Can be provided to use a custom staging table name.
 
     Raises:
         ValueError: If the DataFrame is empty or if unique_keys are not in the DataFrame.
@@ -345,7 +366,12 @@ def _upsert_df_to_bq(
     # Generate a unique staging table name. Include the timestamp
     # in the name for debugging purposes.
     random_suffix = now().strftime("%Y%m%d%H%M-") + uuid4().hex[:8]
-    staging_table_name = f"{dataset}_{table_name}_{random_suffix}"
+
+    if staging_table_name is not None:
+        staging_table_name = f"{staging_table_name}_{random_suffix}"
+    else:
+        staging_table_name = f"{dataset}_{table_name}_{random_suffix}"
+
     staging_destination = f"{UPSERTS_TEMP_DATASET}.{staging_table_name}"
 
     # Write the incoming data to the staging table.

--- a/packages/op-coreutils/src/op_coreutils/bigquery/write.py
+++ b/packages/op-coreutils/src/op_coreutils/bigquery/write.py
@@ -203,6 +203,8 @@ def overwrite_partition_static(
 
 @dataclass
 class DatePart:
+    """Part of a dataframe corresponding to a single 'dt' value."""
+
     date_df: pl.DataFrame
     date_suffix: str
 

--- a/src/op_analytics/cli/subcommands/pulls/app.py
+++ b/src/op_analytics/cli/subcommands/pulls/app.py
@@ -23,11 +23,14 @@ def l2beat():
 @app.command()
 def defillama_stablecoins(
     symbols: Annotated[
-        str, typer.Argument(help="Comma-separated list of symbols to be processed.")
-    ],
+        str, typer.Option(help="Comma-separated list of symbols to be processed.")
+    ] = None,
 ):
     """Pull stablecoin data from Defillama."""
-    dfl_pull_stablecoins(symbols=[_.strip() for _ in symbols.split(",")])
+    if symbols is not None:
+        symbols = [_.strip() for _ in symbols.split(",")]
+
+    dfl_pull_stablecoins(symbols=symbols)
 
 
 @app.command()

--- a/src/op_analytics/cli/subcommands/pulls/app.py
+++ b/src/op_analytics/cli/subcommands/pulls/app.py
@@ -1,10 +1,12 @@
+from typing import Annotated
+
 import typer
 from op_coreutils.logger import structlog
 
 from .agora import agora_pull
-from .defillama import pull_stables as dfl_pull_stables
-from .l2beat import pull as l2beat_pull
+from .defillama import pull_stablecoins as dfl_pull_stablecoins
 from .github_analytics import pull as github_analytics_pull
+from .l2beat import pull as l2beat_pull
 
 log = structlog.get_logger()
 
@@ -19,9 +21,13 @@ def l2beat():
 
 
 @app.command()
-def dfl_stables():
+def defillama_stablecoins(
+    symbols: Annotated[
+        str, typer.Argument(help="Comma-separated list of symbols to be processed.")
+    ],
+):
     """Pull stablecoin data from Defillama."""
-    dfl_pull_stables()
+    dfl_pull_stablecoins(symbols=[_.strip() for _ in symbols.split(",")])
 
 
 @app.command()

--- a/src/op_analytics/cli/subcommands/pulls/defillama.py
+++ b/src/op_analytics/cli/subcommands/pulls/defillama.py
@@ -102,6 +102,7 @@ def pull_stablecoins(symbols: list[str] | None = None) -> DefillamaStablecoins:
         dataset=BQ_DATASET,
         table_name=METADATA_TABLE,
         unique_keys=["id", "name", "symbol"],
+        create_if_not_exists=False,  # set to True on first run
     )
 
     # Upsert balances to BQ.
@@ -111,6 +112,7 @@ def pull_stablecoins(symbols: list[str] | None = None) -> DefillamaStablecoins:
         dataset=BQ_DATASET,
         table_name=BALANCES_TABLE,
         unique_keys=["dt", "id", "chain"],
+        create_if_not_exists=False,  # set to True on first run
     )
 
     return result
@@ -171,7 +173,8 @@ def single_stablecoin_balances(data: dict) -> tuple[dict, list[dict]]:
         data: Data for this stablecoin as returned by the API
 
     Returns:
-        A list of rows. Each row is information at a point in time.
+        Tuple of metadata dict and balances for this stablecoin.
+        Each item in balances is one data point obtained from DefiLlama.
     """
     metadata = single_stablecoin_metadata(data)
     peg_type: str = data["pegType"]

--- a/tests/op_coreutils/bigquery/test_write.py
+++ b/tests/op_coreutils/bigquery/test_write.py
@@ -49,12 +49,6 @@ def test_overwrite_unpartitioned_table():
     assert kwargs["destination"] == "test_dataset.test_table_staging"
     assert kwargs["job_config"].write_disposition == "WRITE_TRUNCATE"
 
-    # Testing with incorrect table name to raise custom error
-    with pytest.raises(
-        OPLabsBigQueryError, match="cannot overwrite data at test_dataset.test_table"
-    ):
-        overwrite_unpartitioned_table(test_df, "test_dataset", "test_table")
-
 
 def test_overwrite_partitioned_table():
     mock_client = init_client()
@@ -64,12 +58,6 @@ def test_overwrite_partitioned_table():
     args, kwargs = mock_client.load_table_from_file.call_args
     assert kwargs["destination"] == "test_dataset.test_table_staging"
     assert kwargs["job_config"].write_disposition == "WRITE_TRUNCATE"
-
-    # Testing with incorrect table name to raise custom error
-    with pytest.raises(
-        OPLabsBigQueryError, match="cannot overwrite data at test_dataset.test_table"
-    ):
-        overwrite_unpartitioned_table(test_df, "test_dataset", "test_table")
 
 
 def test_overwrite_partition_static():


### PR DESCRIPTION
Some notes:

- Instead of filtering by stablecoin ids suggest that we filter by symbol since it is more human friendly.
- Finished plugging the filter to the CLI command so it can be used when calling the CLI.
- Modified the biguqery upssert partitioned table function so it can handle dataframes that have multiple dt values.
- Also added a flag to create the table if upserting for the first time.
- Revisit the bigquery table names and only make two calls to write to bigquery. We were saving a history table that does not seem necessary.
- Pull apart more functions in defillama.py to make it easier to parse. 
- Renamed various things, we used the name `breakout` but that doesn't really tell us much. Using `balances` which I think is better but open to suggestions. 
-  Made the `n_days` parameter a constant instead. Wasn't seeing the need to expose it as a parameter.