### PR TITLE
typo correction readme.md

### DIFF
--- a/protocol_analysis/fjord_scalar_recommendations/readme.md
+++ b/protocol_analysis/fjord_scalar_recommendations/readme.md
@@ -1,11 +1,11 @@
-### Analaysis
+### Analysis
 **Purpose:** To recommend Fee Scalar updates for the Fjord hard fork. In Ecotone, compressed transaction size was estimated by dividing the l1GasUsed for a transaction by 16. In Fjord, the [RLP-encoded](https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/) transactions are sent through the [FastLZ](https://github.com/ariya/FastLZ) compression algorithm to generate an `estimatedSize` for the transaction, which becomes how users are charged for L1/Blob gas.
 
 **Todos:**
 1. Understand the average estimatedSize per transaction for the higher volume chains
-  - Pull transactions from Goldsky/Clickhouse by chain -> RLP-Econde transaction input data (count bytes) -> run through FastLZ (count bytes)
+  - Pull transactions from Goldsky/Clickhouse by chain -> RLP-Encode transaction input data (count bytes) -> run through FastLZ (count bytes)
 2. Approximate accuracy by comparing total estimatedSize on L2 vs blobgas used on L1 (and gas if calldata for chains that may use calldata)
-  - This should be a bit of an underestimate, since we'll have brotli compression in Fjord. We ~could handle for this by assuming some extra compression? But v1 likely should not mess with this.
+  - This should be a bit of an underestimate, since we'll have brotli compression in Fjord. We ~could handle this by assuming some extra compression? But v1 likely should not mess with this.
 
 - (1) and (2) are inputs to the Fee Scalar Recommendation logic :squidward_dab:
 


### PR DESCRIPTION
1.Typo in Section Header:
"Analaysis" should be "Analysis".

2.Typo in Bullet Points:
"RLP-Econde" should be "RLP-Encode".

3.Grammar in Parenthesis:
"we ~could handle for this" could be better as  "we ~could handle this".