### PR TITLE
Skip older data to speed up processing

### DIFF
--- a/src/op_analytics/cli/subcommands/pulls/defillama/protocols.py
+++ b/src/op_analytics/cli/subcommands/pulls/defillama/protocols.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import timedelta
 
 import polars as pl
 
@@ -9,7 +10,7 @@ from op_analytics.coreutils.bigquery.write import (
 from op_analytics.coreutils.logger import structlog
 from op_analytics.coreutils.request import get_data, new_session
 from op_analytics.coreutils.threads import run_concurrently
-from op_analytics.coreutils.time import dt_fromepoch
+from op_analytics.coreutils.time import date_fromstr, dt_fromepoch, now_date
 
 log = structlog.get_logger()
 
@@ -22,6 +23,8 @@ PROTOCOL_TVL_DATA_TABLE = "defillama_protocols_tvl"
 PROTOCOL_TOKEN_TVL_DATA_TABLE = "defillama_protocols_token_tvl"
 
 TVL_TABLE_LAST_N_DAYS = 7
+
+TVL_TABLE_CUTOFF_DATE = now_date() - timedelta(TVL_TABLE_LAST_N_DAYS)
 
 
 @dataclass
@@ -166,11 +169,16 @@ def extract_protocol_tvl_to_dataframes(protocol_data: dict) -> pl.DataFrame:
             # Extract total app tvl
             tvl_entries = chain_data.get("tvl", [])
             for tvl_entry in tvl_entries:
+                dateval = dt_fromepoch(tvl_entry["date"])
+
+                if date_fromstr(dateval) < TVL_TABLE_CUTOFF_DATE:
+                    continue
+
                 app_tvl_records.append(
                     {
                         "protocol_slug": slug,
                         "chain": chain,
-                        "date": dt_fromepoch(tvl_entry["date"]),
+                        "date": dateval,
                         "total_app_tvl": tvl_entry.get("totalLiquidityUSD"),
                     }
                 )
@@ -178,14 +186,18 @@ def extract_protocol_tvl_to_dataframes(protocol_data: dict) -> pl.DataFrame:
             # Extract token tvl for each app
             tokens_entries = chain_data.get("tokensInUsd", [])
             for tokens_entry in tokens_entries:
-                date = dt_fromepoch(tokens_entry["date"])
+                dateval = dt_fromepoch(tokens_entry["date"])
+
+                if date_fromstr(dateval) < TVL_TABLE_CUTOFF_DATE:
+                    continue
+
                 token_tvls = tokens_entry.get("tokens", [])
                 for token in token_tvls:
                     app_token_tvl_records.append(
                         {
                             "protocol_slug": slug,
                             "chain": chain,
-                            "date": date,
+                            "date": dateval,
                             "token": token,
                             "app_token_tvl": token_tvls[token],
                         }


### PR DESCRIPTION
The function that assembles the dataframe now runs in ~40s, down from ~1m30s

```
BEFORE:
2024-11-20 13:51:48 [info     ] begin extract protocol tvl     filename=protocols.py lineno=59
2024-11-20 13:53:18 [info     ] DRYRUN WRITE_EMPTY:

AFTER:
2024-11-20 14:08:55 [info     ] begin extract protocol tvl     filename=protocols.py lineno=64
2024-11-20 14:09:32 [info     ] DRYRUN WRITE_EMPTY: 
```

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
