### PR TITLE
Add new functionality to parse isoformats to time.py

### DIFF
--- a/src/op_analytics/coreutils/time.py
+++ b/src/op_analytics/coreutils/time.py
@@ -64,3 +64,10 @@ def surrounding_dates(dateval: date) -> list[date]:
 def epoch_is_date(epoch: int) -> bool:
     """Return true if seconds since epoch is at exactly midnight."""
     return epoch % 86400 == 0
+
+
+def parse_isoformat_with_z(iso_string):
+    """Parse ISO format strings with 'Z' to datetime objects."""
+    if iso_string.endswith("Z"):
+        iso_string = iso_string[:-1] + "+00:00"
+    return datetime.fromisoformat(iso_string)


### PR DESCRIPTION
We are ingesting datetime strings of this manner: "2023-07-09T13:47:17.000Z" from the Agora Api and currently they cannot be processed via any function available in time.py.

Specifically

- The date_fromstr function expects a date string in YYYY-MM-DD format, not a full ISO timestamp.
- Other functions like datetime_fromepoch or date_toepoch work with epoch values and not ISO 8601 strings.

This small PR introduces a way to achieve that.