### PR TITLE
Default write to LOCAL on daily data pull writes

### DIFF
--- a/src/op_analytics/cli/subcommands/pulls/defillama/dataaccess.py
+++ b/src/op_analytics/cli/subcommands/pulls/defillama/dataaccess.py
@@ -42,9 +42,6 @@ class DefiLlama(str, Enum):
             root_path=self.root_path,
             dataframe=dataframe,
             sort_by=sort_by,
-            # Override the location value here. To write to the local file system
-            # use DataLocation.LOCAL
-            location=DataLocation.GCS,
         )
 
     def read(


### PR DESCRIPTION
This should make it easier when developing new data pulls.  And writing to GCS will be limited to Github Actions or k8s unless it is manually overridden locally. 

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
