### PR TITLE
Updates to daily address summary -> move to v2

### DIFF
--- a/src/op_analytics/datapipeline/models/code/daily_address_summary.py
+++ b/src/op_analytics/datapipeline/models/code/daily_address_summary.py
@@ -10,7 +10,7 @@ from op_analytics.datapipeline.models.compute.types import NamedRelations
         "ingestion/transactions_v1",
     ],
     expected_outputs=[
-        "summary_v1",
+        "summary_v2",
     ],
     auxiliary_views=[
         "refined_transactions_fees",
@@ -40,4 +40,4 @@ def daily_address_summary(
         },
     )
 
-    return {"summary_v1": result}
+    return {"summary_v2": result}

--- a/src/op_analytics/datapipeline/models/templates/daily_address_summary.sql.j2
+++ b/src/op_analytics/datapipeline/models/templates/daily_address_summary.sql.j2
@@ -2,6 +2,7 @@ SELECT
   dt
   , chain
   , chain_id
+  , network
   , from_address AS address
   -- Aggregates
 
@@ -43,9 +44,9 @@ SELECT
 
   , sum(if(success, l2_gas_used, 0)) AS success_l2_gas_used_sum
 
-  , sum(l1_gas_used_unified) AS l1_gas_used_sum
+  , sum(l1_gas_used_unified) AS l1_gas_used_unified_sum
 
-  , sum(if(success, l1_gas_used_unified, 0)) AS success_l1_gas_used_sum
+  , sum(if(success, l1_gas_used_unified, 0)) AS success_l1_gas_used_unified_sum
 
   , wei_to_eth(sum(tx_fee)) AS tx_fee_sum_eth
 
@@ -87,11 +88,27 @@ SELECT
 
   , wei_to_gwei(safe_div(sum(l1_blob_fee), sum(l1_blob_scaled_size)))
     AS l1_blob_fee_avg_gwei
+
+  -- Data Processed
+  , sum(input_zero_bytes) AS input_zero_bytes_sum
+  , sum(if(success, input_zero_bytes, 0)) AS success_input_zero_bytes_sum
+
+  , sum(input_byte_length - input_zero_bytes) AS input_nonzero_bytes_sum
+  , sum(if(success, input_byte_length - input_zero_bytes, 0)) AS success_input_nonzero_bytes_sum
+
+  , sum(input_byte_length) AS input_byte_length_sum
+  , sum(if(success, input_byte_length, 0)) AS success_input_byte_length_sum
+
+  , sum(estimated_size) AS estimated_size_sum
+  , sum(if(success, estimated_size, 0)) AS success_estimated_size_sum
+
 FROM
   {{ refined_transactions_fees }}
-WHERE gas_price > 0
+WHERE
+  NOT is_system_transaction
 GROUP BY
   1
   , 2
   , 3
   , 4
+  , 5

--- a/src/op_analytics/datapipeline/models/templates/refined_transactions_fees.sql.j2
+++ b/src/op_analytics/datapipeline/models/templates/refined_transactions_fees.sql.j2
@@ -134,11 +134,11 @@ SELECT
   , wei_to_eth(l1_fee) AS l1_fee_native
   , wei_to_eth(l2_fee) AS l2_fee_native
 
-  -- L1 Breakdown
+  -- Native L1 Breakdown
   , wei_to_eth(l1_base_fee) AS l1_base_fee_native
   , wei_to_eth(l1_blob_fee) AS l1_blob_fee_native
 
-  -- L2 Breakdown
+  -- Native L2 Breakdown
   , wei_to_eth(l2_base_fee) AS l2_base_fee_native
   , wei_to_eth(l2_priority_fee) AS l2_priority_fee_native
   , wei_to_eth(l2_legacy_extra_fee) AS l2_legacy_extra_fee_native

--- a/tests/op_datasets/etl/intermediate/models/test_daily_address_summary.py
+++ b/tests/op_datasets/etl/intermediate/models/test_daily_address_summary.py
@@ -31,7 +31,7 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
         assert self._duckdb_context is not None
 
         ans = self._duckdb_context.client.sql(f"""
-        SELECT * FROM summary_v1 WHERE address = '{SYSTEM_ADDRESS}'
+        SELECT * FROM summary_v2 WHERE address = '{SYSTEM_ADDRESS}'
         """)
 
         assert len(ans) == 0
@@ -41,11 +41,11 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
 
         unique_count = self._duckdb_context.client.sql("""
         SELECT COUNT(*) FROM (
-            SELECT DISTINCT address, chain_id, dt FROM summary_v1
+            SELECT DISTINCT address, chain_id, dt FROM summary_v2
         )
         """)
         total_count = self._duckdb_context.client.sql("""
-        SELECT COUNT(*) FROM summary_v1
+        SELECT COUNT(*) FROM summary_v2
         """)
 
         unique_count_val = (unique_count.fetchone() or [None])[0]
@@ -58,7 +58,7 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
         assert self._duckdb_context is not None
 
         schema = (
-            self._duckdb_context.client.sql("DESCRIBE summary_v1")
+            self._duckdb_context.client.sql("DESCRIBE summary_v2")
             .pl()
             .select("column_name", "column_type")
             .to_dicts()
@@ -69,6 +69,7 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
             "dt": "DATE",
             "chain": "VARCHAR",
             "chain_id": "INTEGER",
+            "network": "VARCHAR",
             "address": "VARCHAR",
             "tx_cnt": "BIGINT",
             "success_tx_cnt": "BIGINT",
@@ -89,8 +90,8 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
             "method_id_ucnt": "BIGINT",
             "l2_gas_used_sum": "DECIMAL(38,0)",
             "success_l2_gas_used_sum": "DECIMAL(38,0)",
-            "l1_gas_used_sum": "DECIMAL(38,0)",
-            "success_l1_gas_used_sum": "DECIMAL(38,0)",
+            "l1_gas_used_unified_sum": "DECIMAL(38,0)",
+            "success_l1_gas_used_unified_sum": "DECIMAL(38,0)",
             "tx_fee_sum_eth": "DECIMAL(38,19)",
             "success_tx_fee_sum_eth": "DECIMAL(38,19)",
             "l2_fee_sum_eth": "DECIMAL(38,19)",
@@ -105,6 +106,14 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
             "l2_priority_price_avg_gwei": "DECIMAL(38,10)",
             "l1_base_price_avg_gwei": "DECIMAL(38,10)",
             "l1_blob_fee_avg_gwei": "DECIMAL(38,10)",
+            "input_zero_bytes_sum": "DECIMAL(38,0)",
+            "success_input_zero_bytes_sum": "DECIMAL(38,0)",
+            "input_nonzero_bytes_sum": "DECIMAL(38,0)",
+            "success_input_nonzero_bytes_sum": "DECIMAL(38,0)",
+            "input_byte_length_sum": "DECIMAL(38,0)",
+            "success_input_byte_length_sum": "DECIMAL(38,0)",
+            "estimated_size_sum": "DECIMAL(38,0)",
+            "success_estimated_size_sum": "DECIMAL(38,0)",
         }
 
     def test_single_txs_output(self):
@@ -115,7 +124,7 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
 
         actual = (
             self._duckdb_context.client.sql(f"""
-        SELECT * FROM summary_v1 WHERE address == '{SINGLE_TX_ADDRESS}'
+        SELECT * FROM summary_v2 WHERE address == '{SINGLE_TX_ADDRESS}'
         """)
             .pl()
             .to_dicts()
@@ -126,6 +135,7 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
                 "dt": date(2024, 10, 1),
                 "chain": "op",
                 "chain_id": 10,
+                "network": "mainnet",
                 "address": "0xd666115c3d251bece7896297bf446ea908caf035",
                 "tx_cnt": 1,
                 "success_tx_cnt": 1,
@@ -146,8 +156,8 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
                 "method_id_ucnt": 1,
                 "l2_gas_used_sum": Decimal("47038"),
                 "success_l2_gas_used_sum": Decimal("47038"),
-                "l1_gas_used_sum": 1600.0,
-                "success_l1_gas_used_sum": 1600.0,
+                "l1_gas_used_unified_sum": Decimal("1600"),
+                "success_l1_gas_used_unified_sum": Decimal("1600"),
                 "tx_fee_sum_eth": Decimal("2.723088381200E-7"),
                 "success_tx_fee_sum_eth": Decimal("2.723088381200E-7"),
                 "l2_fee_sum_eth": Decimal("2.59593784780E-8"),
@@ -162,6 +172,14 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
                 "l2_priority_price_avg_gwei": Decimal("0.0001000000"),
                 "l1_base_price_avg_gwei": Decimal("29.4563635380"),
                 "l1_blob_fee_avg_gwei": Decimal("1.0E-9"),
+                "input_zero_bytes_sum": Decimal("41"),
+                "success_input_zero_bytes_sum": Decimal("41"),
+                "input_nonzero_bytes_sum": Decimal("27"),
+                "success_input_nonzero_bytes_sum": Decimal("27"),
+                "input_byte_length_sum": Decimal("68"),
+                "success_input_byte_length_sum": Decimal("68"),
+                "estimated_size_sum": Decimal("100"),
+                "success_estimated_size_sum": Decimal("100"),
             }
         ]
 
@@ -205,7 +223,7 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
 
         actual = (
             self._duckdb_context.client.sql(f"""
-        SELECT * FROM summary_v1 WHERE address == '{MULTI_TXS_ADDRESS}'
+        SELECT * FROM summary_v2 WHERE address == '{MULTI_TXS_ADDRESS}'
         """)
             .pl()
             .to_dicts()
@@ -216,6 +234,7 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
                 "dt": date(2024, 10, 1),
                 "chain": "op",
                 "chain_id": 10,
+                "network": "mainnet",
                 "address": "0xcef6d40144b0d76617664357a15559ecb145374f",
                 "tx_cnt": 2,
                 "success_tx_cnt": 2,
@@ -236,8 +255,8 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
                 "method_id_ucnt": 1,
                 "l2_gas_used_sum": Decimal("59852"),
                 "success_l2_gas_used_sum": Decimal("59852"),
-                "l1_gas_used_sum": Decimal("3200"),
-                "success_l1_gas_used_sum": Decimal("3200"),
+                "l1_gas_used_unified_sum": Decimal("3200"),
+                "success_l1_gas_used_unified_sum": Decimal("3200"),
                 "tx_fee_sum_eth": Decimal("0.0000037408546364060"),
                 "success_tx_fee_sum_eth": Decimal("0.0000037408546364060"),
                 "l2_fee_sum_eth": Decimal("0.0000035911200000000"),
@@ -252,6 +271,14 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
                 "l2_priority_price_avg_gwei": Decimal("0E-10"),
                 "l1_base_price_avg_gwei": Decimal("8.9519942250"),
                 "l1_blob_fee_avg_gwei": Decimal("1.0E-9"),
+                "input_zero_bytes_sum": Decimal("84"),
+                "success_input_zero_bytes_sum": Decimal("84"),
+                "input_nonzero_bytes_sum": Decimal("52"),
+                "success_input_nonzero_bytes_sum": Decimal("52"),
+                "input_byte_length_sum": Decimal("136"),
+                "success_input_byte_length_sum": Decimal("136"),
+                "estimated_size_sum": Decimal("200"),
+                "success_estimated_size_sum": Decimal("200"),
             }
         ]
 
@@ -276,7 +303,7 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
         assert self._duckdb_context is not None
 
         actual = (
-            self._duckdb_context.client.sql("SELECT SUM(tx_cnt) FROM summary_v1").pl().to_dicts()
+            self._duckdb_context.client.sql("SELECT SUM(tx_cnt) FROM summary_v2").pl().to_dicts()
         )
         assert actual == [{"sum(tx_cnt)": Decimal("2397")}]
 
@@ -308,7 +335,7 @@ class TestDailyAddressSummary001(IntermediateModelTestBase):
                     active_time_range =
                     block_timestamp_max - block_timestamp_min        AS check6
 
-                FROM summary_v1
+                FROM summary_v2
             )
 
             SELECT


### PR DESCRIPTION
These updates are picked up from #1161 where Michael introduced refined traces and some modifications to refined transactions.  

I don't think we are yet using the daily address summary_v1 anywhere, so I think it's ok to move to v2.  

At the end of the day we might not even use v2 in its current form, since it might be better to build the daily aggregate on top of the refined traces and refined txs datasets that are being introduced in #1161 . 

That said, I thought it would be good to save the changes from Michael because we may need to replicate this if we rebuild on top of the refined txs dataset. 


<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
