### PR TITLE
Add skip-ci parameter to CircleCI config and update conditions for de…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,6 +348,7 @@ workflows:
     when:
       or:
         - equal: [<< pipeline.parameters.run_job >>, "deploy_github_pages"]
+        - equal: [<< pipeline.schedule.name >>, "deploy_github_pages"]
         - and:
             - equal: [<< pipeline.git.branch >>, "main"]
             - not:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,9 @@ jobs:
       push:
         type: string
         default: always
+      skip-ci:
+        type: boolean
+        default: false
     machine:
       image: ubuntu-2004:current
     steps:
@@ -176,7 +179,7 @@ jobs:
       - utils/github-commit-and-push-changes:
           condition: << parameters.push >>
           commit-message: "<< parameters.commit-message >>"
-          skip-ci: true
+          skip-ci: << parameters.skip-ci >>
           folder: "op-analytics"
 
   deploy-github-pages:
@@ -345,7 +348,10 @@ workflows:
     when:
       or:
         - equal: [<< pipeline.parameters.run_job >>, "deploy_github_pages"]
-        - equal: [<< pipeline.git.branch >>, "main"]
+        - and:
+            - equal: [<< pipeline.git.branch >>, "main"]
+            - not:
+                equal: [<< pipeline.trigger_source >>, "api"]
     jobs:
       - deploy-github-pages:
           context:


### PR DESCRIPTION
…ployment workflow

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request includes changes to the `.circleci/config.yml` file to add a new parameter for skipping CI and to adjust the conditions for deploying GitHub pages.

Enhancements to CI configuration:

* Added a new `skip-ci` parameter to the `push` job to allow skipping CI builds if set to `false`.
* Updated the `utils/github-commit-and-push-changes` step to use the `skip-ci` parameter instead of a hardcoded value.

Adjustments to deployment conditions:

* Modified the `workflows` section to add a condition for deploying GitHub pages only when the branch is `main` and the trigger source is not `api`.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
