### PR TITLE
Add function to create bq external tables. Use a parameterized view in clickhouse so we can filter by partitions

### DIFF
--- a/src/op_analytics/coreutils/bigquery/client.py
+++ b/src/op_analytics/coreutils/bigquery/client.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock
+
+from google.cloud import bigquery
+
+from op_analytics.coreutils.env.aware import OPLabsEnvironment, current_environment
+from op_analytics.coreutils.gcpauth import get_credentials
+from op_analytics.coreutils.logger import structlog
+
+log = structlog.get_logger()
+
+_CLIENT: bigquery.Client | MagicMock | None = None
+
+
+# This dataset is used to store staging tables used in upsert operations.
+# It is already configured with a default table expiration time of 1 day.
+UPSERTS_TEMP_DATASET = "temp_upserts"
+
+
+def init_client():
+    """BigQuery client with environment and testing awareness."""
+    global _CLIENT
+
+    if _CLIENT is None:
+        current_env = current_environment()
+
+        if current_env == OPLabsEnvironment.PROD:
+            _CLIENT = bigquery.Client(credentials=get_credentials())
+        else:
+            # MagicMock is used when running tests or when the PROD env is not specified.
+            # This is helpful to collect data and iterate on transformations without
+            # accidentally writing data to BigQuery before the final logic is in place.
+            _CLIENT = MagicMock()
+
+    if _CLIENT is None:
+        raise RuntimeError("BigQuery client was not properly initialized.")
+
+    return _CLIENT

--- a/src/op_analytics/coreutils/bigquery/gcsview.py
+++ b/src/op_analytics/coreutils/bigquery/gcsview.py
@@ -1,0 +1,40 @@
+from op_analytics.coreutils.logger import structlog
+
+from .write import init_client
+
+log = structlog.get_logger()
+
+
+def create_gcs_view(
+    db_name: str,
+    table_name: str,
+    partition_columns: str,
+    partition_prefix: str,
+):
+    """Create a VIEW over data stored in GCS.
+
+    The "partition_selection" parameters is used to add virtual columns to the view.
+    This is important because virtual columns are how we make partition path information
+    (for example: "chain=base/dt=2025-01-01/") available to consumers of the view.
+    """
+    client = init_client()
+
+    # Construct the SQL DDL statement
+    table_id = f"{db_name}.{table_name}"
+    ddl_statement = f"""
+    CREATE EXTERNAL TABLE `oplabs-tools-data.{table_id}`
+    WITH PARTITION COLUMNS ({partition_columns}) 
+    OPTIONS (
+        format = 'PARQUET',
+        uris = ['gs://oplabs-tools-data-sink/{partition_prefix}/*'],
+        hive_partition_uri_prefix = 'gs://oplabs-tools-data-sink/{partition_prefix}',
+        require_hive_partition_filter = true,
+        decimal_target_types = ["NUMERIC", "BIGNUMERIC"]
+    ) 
+    """
+
+    # Execute the DDL statement
+    query_job = client.query(ddl_statement)
+    query_job.result()  # Wait for the job to complete
+
+    log.info(f"created bigquery view: {table_id}")

--- a/src/op_analytics/coreutils/bigquery/load.py
+++ b/src/op_analytics/coreutils/bigquery/load.py
@@ -5,7 +5,7 @@ from google.cloud import bigquery
 
 from op_analytics.coreutils.logger import structlog
 
-from .write import init_client
+from .client import init_client
 
 log = structlog.get_logger()
 

--- a/src/op_analytics/coreutils/bigquery/write.py
+++ b/src/op_analytics/coreutils/bigquery/write.py
@@ -9,40 +9,17 @@ import polars as pl
 from google.cloud import bigquery
 from google.api_core import exceptions
 
-from op_analytics.coreutils.env.aware import OPLabsEnvironment, current_environment
-from op_analytics.coreutils.gcpauth import get_credentials
 from op_analytics.coreutils.logger import human_rows, human_size, structlog
 from op_analytics.coreutils.time import date_fromstr, now
 
-log = structlog.get_logger()
+from .client import init_client
 
-_CLIENT: bigquery.Client | MagicMock | None = None
+log = structlog.get_logger()
 
 
 # This dataset is used to store staging tables used in upsert operations.
 # It is already configured with a default table expiration time of 1 day.
 UPSERTS_TEMP_DATASET = "temp_upserts"
-
-
-def init_client():
-    """BigQuery client with environment and testing awareness."""
-    global _CLIENT
-
-    if _CLIENT is None:
-        current_env = current_environment()
-
-        if current_env == OPLabsEnvironment.PROD:
-            _CLIENT = bigquery.Client(credentials=get_credentials())
-        else:
-            # MagicMock is used when running tests or when the PROD env is not specified.
-            # This is helpful to collect data and iterate on transformations without
-            # accidentally writing data to BigQuery before the final logic is in place.
-            _CLIENT = MagicMock()
-
-    if _CLIENT is None:
-        raise RuntimeError("BigQuery client was not properly initialized.")
-
-    return _CLIENT
 
 
 class OPLabsBigQueryError(Exception):

--- a/src/op_analytics/dagster/defs.py
+++ b/src/op_analytics/dagster/defs.py
@@ -40,9 +40,11 @@ def create_schedule_for_group(
             name=f"{group}_job",
             selection=AssetSelection.groups(group),
             custom_config=OPK8sConfig(
+                mem_request="2Gi",
+                mem_limit="4Gi",
                 labels={
                     "op-analytics-dagster-group": group,
-                }
+                },
             ),
         ),
         cron_schedule=cron_schedule,


### PR DESCRIPTION
FYI: @chucktraverse parts of this may be useful if you want to breate a BQ external table over the defillama gcs data. 

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
