### PR TITLE
Do not let Decimal() infer the precision on the stablecoin balances schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ sphinx-serve: .makemarkers/sphinx-docs
 # ----------------------------------------------------------------------------#
 
 IMAGE_TAG = ghcr.io/lithium323/op-analytics:v20250116.1
-IMAGE_TAG_DAGSTER = ghcr.io/lithium323/op-analytics-dagster:v20250115.001
+IMAGE_TAG_DAGSTER = ghcr.io/lithium323/op-analytics-dagster:v20250117.002
 
 .PHONY: uv-build
 uv-build:

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -296,7 +296,7 @@ dagster-user-deployments:
       image:
         # When a tag is not supplied, it will default as the Helm chart version.
         repository: "ghcr.io/lithium323/op-analytics-dagster"
-        tag: "v20250115.001"
+        tag: "v20250117.002"
 
         # Change with caution! If you're using a fixed tag for pipeline run images, changing the
         # image pull policy to anything other than "Always" will use a cached/stale image, which is

--- a/src/op_analytics/datasources/defillama/stablecoins.py
+++ b/src/op_analytics/datasources/defillama/stablecoins.py
@@ -1,8 +1,10 @@
+import json
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Optional
 
 import polars as pl
+
 from op_analytics.coreutils.bigquery.write import (
     most_recent_dates,
 )
@@ -65,10 +67,10 @@ BALANCES_DF_SCHEMA = {
     "id": pl.String(),
     "chain": pl.String(),
     "dt": pl.String(),
-    "circulating": pl.Decimal(scale=18),
-    "bridged_to": pl.Decimal(scale=18),
-    "minted": pl.Decimal(scale=18),
-    "unreleased": pl.Decimal(scale=18),
+    "circulating": pl.Decimal(precision=38, scale=18),
+    "bridged_to": pl.Decimal(precision=38, scale=18),
+    "minted": pl.Decimal(precision=38, scale=18),
+    "unreleased": pl.Decimal(precision=38, scale=18),
     "name": pl.String(),
     "symbol": pl.String(),
 }
@@ -169,6 +171,18 @@ def extract(stablecoins_data) -> DefillamaStablecoins:
 
     # Schema assertions to help our future selves reading this code.
     assert metadata_df.schema == METADATA_DF_SCHEMA
+    if balances_df.schema != BALANCES_DF_SCHEMA:
+        actual = json.dumps([f"{_}  {str(__)}" for _, __ in balances_df.schema.items()])
+        expected = json.dumps([f"{_}  {str(__)}" for _, __ in BALANCES_DF_SCHEMA.items()])
+
+        raise Exception(f"""
+        Mismatching schema:
+        
+        {actual}
+        
+        {expected}
+        """)
+
     assert balances_df.schema == BALANCES_DF_SCHEMA
 
     return DefillamaStablecoins(metadata_df=metadata_df, balances_df=balances_df)


### PR DESCRIPTION
This fixes the run that was failing on Dagster. 

Also adds a more helpful error message when we see a schema mismatch.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
