### PR TITLE
Add use_pool parameter to enable faster backfills from laptop

### DIFF
--- a/src/op_analytics/cli/subcommands/chains/app.py
+++ b/src/op_analytics/cli/subcommands/chains/app.py
@@ -114,6 +114,11 @@ FORK_PROCESS_OPTION = Annotated[
     bool, typer.Option(help="If true, execute task in a forked subprocess.")
 ]
 
+USE_POOL_OPTION = Annotated[
+    bool,
+    typer.Option(help="If true, uses a process pool instead of spawning a new process per task."),
+]
+
 
 def normalize_chains(chains: str) -> list[str]:
     # If for some reason we need to force exclude a chain, add it here.
@@ -243,6 +248,7 @@ def blockbatch_models(
     dryrun: DRYRUN_OPTION = False,
     force_complete: FORCE_COMPLETE_OPTION = False,
     fork_process: FORK_PROCESS_OPTION = True,
+    use_pool: USE_POOL_OPTION = False,
 ):
     """Compute blockbatch models for a range of dates."""
     chain_list = normalize_chains(chains)
@@ -257,6 +263,7 @@ def blockbatch_models(
         dryrun=dryrun,
         force_complete=force_complete,
         fork_process=fork_process,
+        use_pool=use_pool,
     )
 
 

--- a/src/op_analytics/datapipeline/etl/blockbatch/main.py
+++ b/src/op_analytics/datapipeline/etl/blockbatch/main.py
@@ -17,6 +17,7 @@ def compute_blockbatch(
     dryrun: bool,
     force_complete: bool = False,
     fork_process: bool = True,
+    use_pool: bool = False,
 ):
     tasks = construct_tasks(chains, models, range_spec, read_from, write_to)
     run_tasks(
@@ -25,4 +26,5 @@ def compute_blockbatch(
         force_complete=force_complete,
         fork_process=fork_process,
         num_processes=4,
+        use_pool=use_pool,
     )

--- a/src/op_analytics/datapipeline/models/compute/runner.py
+++ b/src/op_analytics/datapipeline/models/compute/runner.py
@@ -64,6 +64,12 @@ def run_tasks(
     use_pool: bool = False,
     num_processes: int = 1,
 ):
+    """Run tasks.
+
+    The use_pool=True option should only be used when running locally to speed up backfills.
+    In kubernetes we have had some issues taking advantage of the process pool. So we do fork
+    but we spawn an entirely new process for each task.
+    """
     if dryrun:
         log.info("DRYRUN: No work will be done.")
         return


### PR DESCRIPTION
use_pool was disabled for running in kubernetes. Making it a CLI parameter so we can use it locally. 

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
