### PR TITLE
Fix bug in breakout partitions that was resulting in empty model output data

### DIFF
--- a/src/op_analytics/coreutils/partitioned/partition.py
+++ b/src/op_analytics/coreutils/partitioned/partition.py
@@ -90,9 +90,15 @@ class PartitionData:
         return self.partition.column_value(partition_name)
 
     @classmethod
-    def from_dict(cls, partitions_dict: dict[str, str], df: pl.DataFrame) -> "PartitionData":
+    def from_dict(
+        cls,
+        partition_cols: list[str],
+        partitions_dict: dict[str, str],
+        df: pl.DataFrame,
+    ) -> "PartitionData":
         cols = []
-        for col, val in partitions_dict.items():
+        for col in partition_cols:
+            val = partitions_dict[col]
             # NOTE: Here we validate the type of the "dt" column.
             if col == "dt" and not isinstance(val, (date, str)):
                 raise ValueError(

--- a/src/op_analytics/datapipeline/models/code/token_transfers.py
+++ b/src/op_analytics/datapipeline/models/code/token_transfers.py
@@ -32,6 +32,7 @@ def token_transfers(
     erc721_transfers = all_transfers.filter("token_id IS NOT NULL").project(
         "* EXCLUDE (amount, amount_lossless)"
     )
+
     return {
         "erc20_transfers_v1": erc20_transfers,
         "erc721_transfers_v1": erc721_transfers,

--- a/tests/op_coreutils/partitioned/test_breakout.py
+++ b/tests/op_coreutils/partitioned/test_breakout.py
@@ -88,55 +88,60 @@ def test_breakout_partitions():
     assert actual == EXPECTED_RESULT
 
 
+def pass_through(x):
+    return x
+
+
 def test_breakout_partitions_empty():
-    df = pl.DataFrame(
-        {
-            "dt": [
-                "2024-01-01",
-                "2024-01-01",
-                "2024-01-01",
-                "2024-01-01",
-                "2024-01-02",
-                "2024-01-02",
-                "2024-01-03",
-            ],
-            "chain": ["op", "op", "base", "base", "base", "base", "op"],
-            "c": ["some", "words", "here", "and", "some", "more", "blah"],
-        }
-    )
-
-    outputs: list[PartitionData] = []
-    for part in breakout_partitions(
-        df.filter(pl.col("dt") == ""),  # Filter out all data to get a default empty parquet file
-        partition_cols=["dt", "chain"],
-        default_partitions=[{"chain": "op", "dt": "2023-10-30"}],
-    ):
-        outputs.append(part)
-        assert part.df.columns == ["c"]
-
-    actual = []
-    for _ in outputs:
-        actual.append(
-            dict(
-                partitions=_.partition,
-                full_path=_.partition.path,
-                nu_rows=len(_.df),
-            )
+    for conversion in [pass_through, date_fromstr]:
+        df = pl.DataFrame(
+            {
+                "dt": [
+                    conversion("2024-01-01"),
+                    conversion("2024-01-01"),
+                    conversion("2024-01-01"),
+                    conversion("2024-01-01"),
+                    conversion("2024-01-02"),
+                    conversion("2024-01-02"),
+                    conversion("2024-01-03"),
+                ],
+                "chain": ["op", "op", "base", "base", "base", "base", "op"],
+                "c": ["some", "words", "here", "and", "some", "more", "blah"],
+            }
         )
 
-    actual.sort(key=lambda x: x["full_path"])
-    assert actual == [
-        {
-            "partitions": Partition(
-                [
-                    PartitionColumn(name="chain", value="op"),
-                    PartitionColumn(name="dt", value="2023-10-30"),
-                ]
-            ),
-            "full_path": "chain=op/dt=2023-10-30",
-            "nu_rows": 0,
-        }
-    ]
+        outputs: list[PartitionData] = []
+        for part in breakout_partitions(
+            df.filter(pl.lit(False)),  # Filter out all data to get a default empty parquet file
+            partition_cols=["dt", "chain"],
+            default_partitions=[{"chain": "op", "dt": "2023-10-30"}],
+        ):
+            outputs.append(part)
+            assert part.df.columns == ["c"]
+
+        actual = []
+        for _ in outputs:
+            actual.append(
+                dict(
+                    partitions=_.partition,
+                    full_path=_.partition.path,
+                    nu_rows=len(_.df),
+                )
+            )
+
+        actual.sort(key=lambda x: x["full_path"])
+        assert actual == [
+            {
+                "partitions": Partition(
+                    [
+                        PartitionColumn(name="chain", value="op"),
+                        PartitionColumn(name="dt", value="2023-10-30"),
+                    ]
+                ),
+                "full_path": "chain=op/dt=2023-10-30",
+                "nu_rows": 0,
+            }
+        ]
 
 
 def test_breakout_partitions_date_column_type():
@@ -219,61 +224,62 @@ def test_breakout_partitions_date_value_invalid():
 
 
 def test_breakout_partitions_partially_missing_default_partitions():
-    df = pl.DataFrame(
-        {
-            "dt": [
-                "2024-01-01",
-                "2024-01-01",
-                "2024-01-01",
-                "2024-01-01",
-            ],
-            "chain": ["op", "op", "op", "op"],
-            "c": ["some", "words", "here", "and"],
-        }
-    )
-
-    outputs: list[PartitionData] = []
-    for part in breakout_partitions(
-        df,
-        partition_cols=["dt", "chain"],
-        default_partitions=[
-            {"chain": "op", "dt": "2024-01-01"},
-            {"chain": "op", "dt": "2024-01-02"},
-        ],
-    ):
-        outputs.append(part)
-        assert part.df.columns == ["c"]
-
-    actual = []
-    for _ in outputs:
-        actual.append(
-            dict(
-                partitions=_.partition,
-                full_path=_.partition.path,
-                nu_rows=len(_.df),
-            )
+    for conversion in [pass_through, date_fromstr]:
+        df = pl.DataFrame(
+            {
+                "dt": [
+                    conversion("2024-01-01"),
+                    conversion("2024-01-01"),
+                    conversion("2024-01-01"),
+                    conversion("2024-01-01"),
+                ],
+                "chain": ["op", "op", "op", "op"],
+                "c": ["some", "words", "here", "and"],
+            }
         )
 
-    actual.sort(key=lambda x: x["full_path"])
-    assert actual == [
-        {
-            "partitions": Partition(
-                cols=[
-                    PartitionColumn(name="chain", value="op"),
-                    PartitionColumn(name="dt", value="2024-01-02"),
-                ]
-            ),
-            "full_path": "chain=op/dt=2024-01-02",
-            "nu_rows": 0,
-        },
-        {
-            "partitions": Partition(
-                cols=[
-                    PartitionColumn(name="dt", value="2024-01-01"),
-                    PartitionColumn(name="chain", value="op"),
-                ]
-            ),
-            "full_path": "dt=2024-01-01/chain=op",
-            "nu_rows": 4,
-        },
-    ]
+        outputs: list[PartitionData] = []
+        for part in breakout_partitions(
+            df,
+            partition_cols=["dt", "chain"],
+            default_partitions=[
+                {"chain": "op", "dt": "2024-01-01"},
+                {"chain": "op", "dt": "2024-01-02"},
+            ],
+        ):
+            outputs.append(part)
+            assert part.df.columns == ["c"]
+
+        actual = []
+        for _ in outputs:
+            actual.append(
+                dict(
+                    partitions=_.partition,
+                    full_path=_.partition.path,
+                    num_rows=len(_.df),
+                )
+            )
+
+        actual.sort(key=lambda x: x["full_path"])
+        assert actual == [
+            {
+                "partitions": Partition(
+                    cols=[
+                        PartitionColumn(name="dt", value="2024-01-01"),
+                        PartitionColumn(name="chain", value="op"),
+                    ]
+                ),
+                "full_path": "dt=2024-01-01/chain=op",
+                "num_rows": 4,
+            },
+            {
+                "partitions": Partition(
+                    cols=[
+                        PartitionColumn(name="dt", value="2024-01-02"),
+                        PartitionColumn(name="chain", value="op"),
+                    ]
+                ),
+                "full_path": "dt=2024-01-02/chain=op",
+                "num_rows": 0,
+            },
+        ]


### PR DESCRIPTION
The yielded partitions were not being identified correctly so at the end we would always yield all of the default partitions with empty dataframes, which would result in overwriting with empty data. 

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
