### PR TITLE
Cleanup defillama clickhouse views (we aren't using them at the moment, using BQ)

### DIFF
--- a/src/op_analytics/dagster/assets/defillama.py
+++ b/src/op_analytics/dagster/assets/defillama.py
@@ -108,35 +108,3 @@ def volumes_fees_revenue_views():
     DefiLlama.VOLUME_PROTOCOLS_METADATA.create_clickhouse_view()
     DefiLlama.FEES_PROTOCOLS_METADATA.create_clickhouse_view()
     DefiLlama.REVENUE_PROTOCOLS_METADATA.create_clickhouse_view()
-
-
-@asset(deps=[tvl_breakdown_enrichment])
-def tvl_breakdown_views():
-    """Clickhouse external tables over GCS data:
-
-    - defillama_gcs.protocol_token_tvl_breakdown_v1
-    """
-    from op_analytics.datasources.defillama.dataaccess import DefiLlama
-
-    DefiLlama.PROTOCOL_TOKEN_TVL_BREAKDOWN.create_clickhouse_view()
-
-    # NEXT STEPS. BigQuery view over the results in GCS
-    # DefiLlama.PROTOCOL_TOKEN_TVL_BREAKDOWN.create_bigquery_external_table()
-
-    # NEXT STEPS.
-    # Suppose we want to create a BigQuery view that joins a bunch of tables.
-    # from op_analytics.coreutils.bigquery.write import init_client
-    # bq_client = init_client()
-    # bq_client.sql("""
-    # CREATE VIEW IF NOT EXISTS my_view AS
-    # SELECT * FROM JOIN EVERYTHING ELSE
-    # """)
-
-
-# TODO: Consider not doing this anymore now that we have views over GCS data.
-@asset(deps=[volumes_fees_revenue])
-def volumes_fees_revenue_to_clickhouse(context: OpExecutionContext):
-    from op_analytics.datasources.defillama.volume_fees_revenue import execute
-
-    result = execute.write_to_clickhouse()
-    context.log.info(result)

--- a/src/op_analytics/datasources/defillama/volume_fees_revenue/execute.py
+++ b/src/op_analytics/datasources/defillama/volume_fees_revenue/execute.py
@@ -56,19 +56,6 @@ def execute_pull(current_dt: str | None = None):
     )
 
 
-def write_to_clickhouse():
-    # Capture summaries and return them to have info in Dagster
-    summaries = [
-        DefiLlama.VOLUME_FEES_REVENUE.insert_to_clickhouse(incremental_overlap=3),
-        DefiLlama.VOLUME_FEES_REVENUE_BREAKDOWN.insert_to_clickhouse(incremental_overlap=3),
-        DefiLlama.VOLUME_PROTOCOLS_METADATA.insert_to_clickhouse(),
-        DefiLlama.FEES_PROTOCOLS_METADATA.insert_to_clickhouse(),
-        DefiLlama.REVENUE_PROTOCOLS_METADATA.insert_to_clickhouse(),
-    ]
-
-    return summaries
-
-
 def write(
     chain_df: pl.DataFrame,
     breakdown_df: pl.DataFrame,

--- a/tests/op_analytics/cli/pulls/defillama/test_defillama_protocols.py
+++ b/tests/op_analytics/cli/pulls/defillama/test_defillama_protocols.py
@@ -148,6 +148,18 @@ expected_single_protocol_app_tvl_dicts = [
     {
         "protocol_slug": "protocol_one",
         "chain": "ChainAlpha",
+        "dt": "2024-11-14",
+        "total_app_tvl": 12345.67,
+    },
+    {
+        "protocol_slug": "protocol_one",
+        "chain": "ChainBeta",
+        "dt": "2024-11-14",
+        "total_app_tvl": 34567.89,
+    },
+    {
+        "protocol_slug": "protocol_one",
+        "chain": "ChainAlpha",
         "dt": "2024-11-15",
         "total_app_tvl": 23456.78,
     },
@@ -160,6 +172,38 @@ expected_single_protocol_app_tvl_dicts = [
 ]
 
 expected_single_protocol_app_token_tvl_dicts = [
+    {
+        "protocol_slug": "protocol_one",
+        "chain": "ChainAlpha",
+        "dt": "2024-11-14",
+        "token": "TokenA",
+        "app_token_tvl": 1.1,
+        "app_token_tvl_usd": 5555.55,
+    },
+    {
+        "protocol_slug": "protocol_one",
+        "chain": "ChainAlpha",
+        "dt": "2024-11-14",
+        "token": "TokenB",
+        "app_token_tvl": 2.2,
+        "app_token_tvl_usd": 6666.66,
+    },
+    {
+        "protocol_slug": "protocol_one",
+        "chain": "ChainBeta",
+        "dt": "2024-11-14",
+        "token": "TokenC",
+        "app_token_tvl": 1.2,
+        "app_token_tvl_usd": 1234.56,
+    },
+    {
+        "protocol_slug": "protocol_one",
+        "chain": "ChainBeta",
+        "dt": "2024-11-14",
+        "token": "TokenD",
+        "app_token_tvl": 3.4,
+        "app_token_tvl_usd": 2345.67,
+    },
     {
         "protocol_slug": "protocol_one",
         "chain": "ChainAlpha",
@@ -198,6 +242,24 @@ expected_all_protocol_app_tvl_dicts = [
     {
         "protocol_slug": "protocol_one",
         "chain": "ChainAlpha",
+        "dt": "2024-11-14",
+        "total_app_tvl": 12345.67,
+    },
+    {
+        "protocol_slug": "protocol_one",
+        "chain": "ChainBeta",
+        "dt": "2024-11-14",
+        "total_app_tvl": 34567.89,
+    },
+    {
+        "protocol_slug": "protocol_two",
+        "chain": "ChainGamma",
+        "dt": "2024-11-14",
+        "total_app_tvl": 56789.01,
+    },
+    {
+        "protocol_slug": "protocol_one",
+        "chain": "ChainAlpha",
         "dt": "2024-11-15",
         "total_app_tvl": 23456.78,
     },
@@ -216,6 +278,54 @@ expected_all_protocol_app_tvl_dicts = [
 ]
 
 expected_all_protocol_app_token_tvl_dicts = [
+    {
+        "protocol_slug": "protocol_one",
+        "chain": "ChainAlpha",
+        "dt": "2024-11-14",
+        "token": "TokenA",
+        "app_token_tvl": 1.1,
+        "app_token_tvl_usd": 5555.55,
+    },
+    {
+        "protocol_slug": "protocol_one",
+        "chain": "ChainAlpha",
+        "dt": "2024-11-14",
+        "token": "TokenB",
+        "app_token_tvl": 2.2,
+        "app_token_tvl_usd": 6666.66,
+    },
+    {
+        "protocol_slug": "protocol_one",
+        "chain": "ChainBeta",
+        "dt": "2024-11-14",
+        "token": "TokenC",
+        "app_token_tvl": 1.2,
+        "app_token_tvl_usd": 1234.56,
+    },
+    {
+        "protocol_slug": "protocol_one",
+        "chain": "ChainBeta",
+        "dt": "2024-11-14",
+        "token": "TokenD",
+        "app_token_tvl": 3.4,
+        "app_token_tvl_usd": 2345.67,
+    },
+    {
+        "protocol_slug": "protocol_two",
+        "chain": "ChainGamma",
+        "dt": "2024-11-14",
+        "token": "TokenX",
+        "app_token_tvl": 9.9,
+        "app_token_tvl_usd": 11111.11,
+    },
+    {
+        "protocol_slug": "protocol_two",
+        "chain": "ChainGamma",
+        "dt": "2024-11-14",
+        "token": "TokenY",
+        "app_token_tvl": 8.8,
+        "app_token_tvl_usd": 22222.22,
+    },
     {
         "protocol_slug": "protocol_one",
         "chain": "ChainAlpha",
@@ -364,6 +474,23 @@ def test_pull_single_protocol_tvl(
             "num_rows": 2,
         },
         {
+            "dataset_name": "defillama/protocols_tvl_v1",
+            "df_columns": ["protocol_slug", "chain", "total_app_tvl", "dt"],
+            "num_rows": 2,
+        },
+        {
+            "dataset_name": "defillama/protocols_token_tvl_v1",
+            "df_columns": [
+                "protocol_slug",
+                "chain",
+                "token",
+                "app_token_tvl",
+                "app_token_tvl_usd",
+                "dt",
+            ],
+            "num_rows": 4,
+        },
+        {
             "dataset_name": "defillama/protocols_token_tvl_v1",
             "df_columns": [
                 "protocol_slug",
@@ -439,6 +566,23 @@ def test_pull_all_protocol_tvl(
             "dataset_name": "defillama/protocols_tvl_v1",
             "df_columns": ["protocol_slug", "chain", "total_app_tvl", "dt"],
             "num_rows": 3,
+        },
+        {
+            "dataset_name": "defillama/protocols_tvl_v1",
+            "df_columns": ["protocol_slug", "chain", "total_app_tvl", "dt"],
+            "num_rows": 3,
+        },
+        {
+            "dataset_name": "defillama/protocols_token_tvl_v1",
+            "df_columns": [
+                "protocol_slug",
+                "chain",
+                "token",
+                "app_token_tvl",
+                "app_token_tvl_usd",
+                "dt",
+            ],
+            "num_rows": 6,
         },
         {
             "dataset_name": "defillama/protocols_token_tvl_v1",


### PR DESCRIPTION
A follow up PR will introduce the BQ views. 

This PR also fixes a test that started failing after I changed the last N days values to 120 days.

Eventually I would like to move all Defillama data over to clickhouse, but now is not the time for that given all that we have built on BQ.  I'm removing any existing clickhouse stuff to avoid confusion. 

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
