### PR TITLE
Add ERC20 daily transfers aggregate to clickhouse

### DIFF
--- a/src/op_analytics/transforms/erc20_transfers/create/export_fact_erc20_daily_transfers_v1.sql
+++ b/src/op_analytics/transforms/erc20_transfers/create/export_fact_erc20_daily_transfers_v1.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS _placeholder_
+(
+    `chain` String,
+    `chain_id` Int32,
+    `dt` Date,
+    `network` String,
+    `contract_address` FixedString(66),
+    `num_transfers` UInt64,
+    `num_transactions` UInt64,
+    `num_blocks` UInt64,
+    `num_from_addresses` UInt64,
+    `num_to_addresses` UInt64,
+    `amount_raw` UInt256,
+    INDEX chain_idx chain TYPE minmax GRANULARITY 1,
+    INDEX contract_address_idx contract_address TYPE minmax GRANULARITY 1
+)
+ENGINE = ReplacingMergeTree()
+ORDER BY (chain, chain_id, dt, network, contract_address)

--- a/src/op_analytics/transforms/erc20_transfers/update/01_export_fact_erc20_daily_transfers_v1.sql
+++ b/src/op_analytics/transforms/erc20_transfers/update/01_export_fact_erc20_daily_transfers_v1.sql
@@ -1,0 +1,16 @@
+SELECT
+  chain
+  , chain_id
+  , dt
+  , network
+  , contract_address
+  , COUNT(*) AS num_transfers
+  , COUNT(DISTINCT transaction_hash) AS num_transactions
+  , COUNT(DISTINCT block_number) AS num_blocks
+  , COUNT(DISTINCT from_address) AS num_from_addresses
+  , COUNT(DISTINCT to_address) AS num_to_addresses
+  , SUM(amount) AS amount_raw
+FROM blockbatch.token_transfers__erc20_transfers_v1
+WHERE
+  dt = {dtparam:Date}
+GROUP BY 1, 2, 3, 4, 5


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
- Adding a summary table for erc20 transfers on daily basis, this can later be used for us to filter tokens for token metadata pull via RPC. 
- Quick check that 75 percentile amounts to around 5k tokens to get metadata, and 90 percentile is around 1.6K. I imagine the initial pull might be large since we have nothing and the RPC call should reduce after the first data pull cc: @lithium323 
- Also adding the `raw_amount` transferred here but I'd like to see a future enriched table with amount in decimals and with volume in USD

I guess this one serves a different purpose v.s. top contracts with what token transferred but lemme know anything is missing @MSilb7 
