### PR TITLE
Use the DailyData.write method to write token mappings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ sphinx-serve: .makemarkers/sphinx-docs
 # ----------------------------------------------------------------------------#
 
 IMAGE_TAG = ghcr.io/lithium323/op-analytics:v20250211.3
-IMAGE_TAG_DAGSTER = ghcr.io/lithium323/op-analytics-dagster:v20250217.002
+IMAGE_TAG_DAGSTER = ghcr.io/lithium323/op-analytics-dagster:v20250217.003
 
 .PHONY: uv-build
 uv-build:

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -296,7 +296,7 @@ dagster-user-deployments:
       image:
         # When a tag is not supplied, it will default as the Helm chart version.
         repository: "ghcr.io/lithium323/op-analytics-dagster"
-        tag: "v20250217.002"
+        tag: "v20250217.003"
 
         # Change with caution! If you're using a fixed tag for pipeline run images, changing the
         # image pull policy to anything other than "Always" will use a cached/stale image, which is

--- a/src/op_analytics/dagster/assets/defillama.py
+++ b/src/op_analytics/dagster/assets/defillama.py
@@ -42,6 +42,14 @@ def tvl_breakdown_enrichment(context: AssetExecutionContext):
     result = tvl_breakdown_enrichment.execute_pull()
     context.log.info(result)
 
+    from op_analytics.datapipeline.etl.bigqueryviews.view import create_view
+
+    create_view(
+        db_name="dailydata_defillama",
+        view_name="defillama_tvl_breakdown_filtered",
+        disposition="replace",
+    )
+
 
 @asset
 def historical_chain_tvl(context: AssetExecutionContext):
@@ -104,10 +112,4 @@ def defillama_views():
 
     DefiLlama.YIELD_POOLS_HISTORICAL.create_bigquery_external_table()
 
-    from op_analytics.datapipeline.etl.bigqueryviews.view import create_view
-
-    create_view(
-        db_name="dailydata_defillama",
-        view_name="defillama_tvl_breakdown_filtered",
-        disposition="replace",
-    )
+    DefiLlama.TOKEN_MAPPINGS.create_bigquery_external_table()

--- a/src/op_analytics/dagster/defs.py
+++ b/src/op_analytics/dagster/defs.py
@@ -88,6 +88,10 @@ defs = Definitions(
             cron_schedule="0 3 * * *",  # Runs at 3 AM daily
             default_status=DefaultScheduleStatus.RUNNING,
             k8s_pod_per_step=True,
+            custom_k8s_config=OPK8sConfig(
+                mem_request="4Gi",
+                mem_limit="6Gi",
+            ),
         ),
         #
         create_schedule_for_group(

--- a/src/op_analytics/datapipeline/etl/bigqueryviews/ddl/dailydata_defillama/defillama_tvl_breakdown_filtered.sql
+++ b/src/op_analytics/datapipeline/etl/bigqueryviews/ddl/dailydata_defillama/defillama_tvl_breakdown_filtered.sql
@@ -16,7 +16,7 @@ SELECT
   , tvl.app_token_tvl_usd
 
 FROM `oplabs-tools-data.dailydata_defillama.protocol_token_tvl_breakdown_v1` tvl 
-LEFT JOIN `oplabs-tools-data.defillama.token_mappings` tm 
+LEFT JOIN `oplabs-tools-data.dailydata_defillama.dim_token_mappings_v1` tm 
   ON tvl.token = tm.token
 
 -- NOTE: Chain metadata is something we would like to modify to another source

--- a/src/op_analytics/datasources/defillama/dataaccess.py
+++ b/src/op_analytics/datasources/defillama/dataaccess.py
@@ -40,3 +40,6 @@ class DefiLlama(DailyDataset):
 
     # TVL breakdown
     PROTOCOL_TOKEN_TVL_BREAKDOWN = "protocol_token_tvl_breakdown_v1"
+
+    # Token Mappings
+    TOKEN_MAPPINGS = "dim_token_mappings_v1"

--- a/src/op_analytics/datasources/defillama/token_mappings.py
+++ b/src/op_analytics/datasources/defillama/token_mappings.py
@@ -37,7 +37,7 @@ def load_data_from_gsheet(gsheet_name: str, expected_schema: dict) -> pl.DataFra
     # Validate schema
     raise_for_schema_mismatch(
         actual_schema=raw_df.schema,
-        expected_schema=expected_schema,
+        expected_schema=pl.Schema(expected_schema),
     )
 
     return raw_df

--- a/src/op_analytics/datasources/defillama/token_mappings.py
+++ b/src/op_analytics/datasources/defillama/token_mappings.py
@@ -1,12 +1,14 @@
 import polars as pl
 
 from op_analytics.coreutils.gsheets import read_gsheet
-from op_analytics.coreutils.bigquery.write import overwrite_unpartitioned_table
+from op_analytics.coreutils.misc import raise_for_schema_mismatch
+from op_analytics.coreutils.partitioned.dailydata import DEFAULT_DT
 
-BQ_DATASET = "defillama"
+from .dataaccess import DefiLlama
+
 
 TOKEN_MAPPINGS_GSHEET_NAME = "token_mappings"
-TOKEN_MAPPINGS_TABLE = "token_mappings"
+
 TOKEN_MAPPINGS_SCHEMA = {
     "token": pl.String,
     "token_category": pl.String,
@@ -17,7 +19,9 @@ TOKEN_MAPPINGS_SCHEMA = {
 
 def execute():
     df = load_data_from_gsheet(TOKEN_MAPPINGS_GSHEET_NAME, TOKEN_MAPPINGS_SCHEMA)
-    upload_dataframe(df, TOKEN_MAPPINGS_TABLE)
+
+    # Overwrite at default dt
+    DefiLlama.TOKEN_MAPPINGS.write(dataframe=df.with_columns(dt=pl.lit(DEFAULT_DT)))
 
     return {TOKEN_MAPPINGS_GSHEET_NAME: len(df)}
 
@@ -31,17 +35,9 @@ def load_data_from_gsheet(gsheet_name: str, expected_schema: dict) -> pl.DataFra
     raw_df = pl.DataFrame(raw_records, infer_schema_length=len(raw_records))
 
     # Validate schema
-    assert (
-        raw_df.schema == expected_schema
-    ), f"Schema mismatch. Expected {expected_schema}, got {raw_df.schema}"
+    raise_for_schema_mismatch(
+        actual_schema=raw_df.schema,
+        expected_schema=expected_schema,
+    )
 
     return raw_df
-
-
-def upload_dataframe(df: pl.DataFrame, table_name: str):
-    """Upload overwite a dataframe to BigQuery as an unpartitioned table."""
-    overwrite_unpartitioned_table(
-        df=df,
-        dataset=BQ_DATASET,
-        table_name=table_name,
-    )

--- a/src/op_analytics/datasources/defillama/tvl_breakdown_enrichment.py
+++ b/src/op_analytics/datasources/defillama/tvl_breakdown_enrichment.py
@@ -42,6 +42,21 @@ EXCLUDE_CATEGORIES = [
 DEFAULT_LOOKBACK_DAYS = 30
 
 
+def execute_pull():
+    # Produce the result.
+    result = DefillamaTVLBreakdown.of_date()
+
+    # Write to storage.
+    DefiLlama.PROTOCOL_TOKEN_TVL_BREAKDOWN.write(
+        dataframe=result.df_tvl_breakdown,
+        sort_by=["chain", "protocol_slug", "token"],
+    )
+
+    return {
+        "df_tvl_breakdown": dt_summary(result.df_tvl_breakdown),
+    }
+
+
 @dataclass
 class DefillamaTVLBreakdown:
     df_tvl_breakdown: pl.DataFrame
@@ -153,20 +168,6 @@ def data_quality_check(df_tvl_breakdown: pl.DataFrame, min_date: date, max_date:
         {'\n'.join(extra_dts)}
         """
         raise Exception(f"possibly missing data after transformation: {summary}")
-
-
-def execute_pull():
-    result = DefillamaTVLBreakdown.of_date()
-
-    # Write to storage
-    DefiLlama.PROTOCOL_TOKEN_TVL_BREAKDOWN.write(
-        dataframe=result.df_tvl_breakdown,
-        sort_by=["chain", "protocol_slug", "token"],
-    )
-
-    return {
-        "df_tvl_breakdown": dt_summary(result.df_tvl_breakdown),
-    }
 
 
 def process_data_fields(df: pl.DataFrame) -> pl.DataFrame:


### PR DESCRIPTION
Instead of writing directly to BQ switch to writing to GCS. 

This brings this table into the DailyData framework so we can more easily monitor it in go/pipeline. It also makes it possible to read the data from Clickhouse. 

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
