### PR TITLE
Tweak speed bump and retry settings on ERC20 metadata pull to avoid being rate limited

### DIFF
--- a/src/op_analytics/datasources/chainsmeta/erc20tokens/chaintokens.py
+++ b/src/op_analytics/datasources/chainsmeta/erc20tokens/chaintokens.py
@@ -67,7 +67,7 @@ class ChainTokens:
                     token_metadata = token.call_rpc(
                         session=session,
                         rpc_endpoint=self.rpc_endpoint,
-                        speed_bump=0.5,  # avoid hitting the RPC rate limit
+                        speed_bump=0.6,  # avoid hitting the RPC rate limit
                     )
 
                     if token_metadata is None:

--- a/src/op_analytics/datasources/chainsmeta/erc20tokens/tokens.py
+++ b/src/op_analytics/datasources/chainsmeta/erc20tokens/tokens.py
@@ -84,7 +84,7 @@ class Token:
 
         return batch
 
-    @stamina.retry(on=RateLimit, attempts=3, wait_initial=4)
+    @stamina.retry(on=RateLimit, attempts=3, wait_initial=5)
     def call_rpc(
         self,
         session: requests.Session,


### PR DESCRIPTION
…

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
