### PR TITLE
Store decoder registry in the duckdb context and not globally

### DIFF
--- a/k8s/models-4337-backfill-pt2.yaml
+++ b/k8s/models-4337-backfill-pt2.yaml
@@ -12,7 +12,7 @@ spec:
   parallelism: 14          # How many pods can run in parallel
   completionMode: Indexed # This makes it an indexed job
   ttlSecondsAfterFinished: null
-  backoffLimit: 0
+  backoffLimit: 3
   template:
     metadata:
       annotations:
@@ -35,16 +35,16 @@ spec:
         - name: DUCKDB_DATADIR
           value: "/duckdbdata"
         - name: DUCKDB_MEMORY_LIMIT
-          value: "3"
+          value: "6"
         resources:
           limits:
             cpu: 1
             ephemeral-storage: 10Gi
-            memory: 3Gi
+            memory: 6Gi
           requests:
             cpu: 1
             ephemeral-storage: 10Gi
-            memory: 2Gi
+            memory: 4Gi
         volumeMounts:
         - mountPath: "/var/secrets"
           name: opanalyticsvault
@@ -58,7 +58,6 @@ spec:
           readOnly: true
           volumeAttributes:
             secretProviderClass: op-analytics-secret-provider-class
-
       - name: duckdbdata
         emptyDir:
           sizeLimit: 100Gi

--- a/src/op_analytics/coreutils/duckdb_inmem/client.py
+++ b/src/op_analytics/coreutils/duckdb_inmem/client.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from threading import Lock
 
 import duckdb
@@ -28,6 +28,8 @@ class DuckDBContext:
     python_udfs_ready: bool = False
 
     is_closed: bool = False
+
+    registered_functions: list[str] = field(default_factory=list)
 
     @property
     def db_path(self):

--- a/src/op_analytics/datapipeline/models/decode/register.py
+++ b/src/op_analytics/datapipeline/models/decode/register.py
@@ -8,8 +8,6 @@ from op_analytics.coreutils.logger import structlog
 
 log = structlog.get_logger()
 
-REGISTERED_FUNCTIONS = []
-
 
 def register_decoder(
     ctx: DuckDBContext,
@@ -20,7 +18,7 @@ def register_decoder(
 ):
     """Register a DuckDB function to decode data."""
 
-    if duckdb_function_name in REGISTERED_FUNCTIONS:
+    if duckdb_function_name in ctx.registered_functions:
         log.warning(f"duckdb function is already registered: {duckdb_function_name}")
         return
 
@@ -37,4 +35,4 @@ def register_decoder(
         return_type=DuckDBPyType(return_type),
     )
 
-    REGISTERED_FUNCTIONS.append(duckdb_function_name)
+    ctx.registered_functions.append(duckdb_function_name)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
