### PR TITLE
Avoid input data ready bug in blockbatch models

### DIFF
--- a/src/op_analytics/cli/subcommands/chains/app.py
+++ b/src/op_analytics/cli/subcommands/chains/app.py
@@ -160,7 +160,6 @@ def normalize_blockbatch_models(models: str) -> list[str]:
             result.add("refined_traces")
             result.add("token_transfers")
             result.add("account_abstraction_prefilter")
-            result.add("account_abstraction")
         elif model.startswith("-"):
             not_included.add(model.removeprefix("-").strip())
         else:
@@ -330,7 +329,7 @@ def noargs_blockbatch():
     compute_blockbatch(
         chains=normalize_chains("ALL"),
         models=normalize_blockbatch_models("MODELS"),
-        range_spec="m8hours",
+        range_spec="m12hours",
         read_from=DataLocation.GCS,
         write_to=DataLocation.GCS,
         dryrun=False,


### PR DESCRIPTION
Remove account_abstraction model from list of ALL models to avoid input data ready bug

When the blockbatch runner creates readers it creates one reader per block for all models that reader decides whether the data is ready or not at instantiation. If we include models that depend on other models then readers are never ready. For that reason blockbatch tasks were not running at all and started getting delayed.

This fix solves the problem temporarily until a more permanent solution is found.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
