### PR TITLE
BQ load updates

### DIFF
--- a/src/op_analytics/datapipeline/etl/loadbq/load.py
+++ b/src/op_analytics/datapipeline/etl/loadbq/load.py
@@ -21,8 +21,15 @@ def load_blockbatch_to_bq(
     dryrun: bool,
     force_complete: bool,
     force_not_ready: bool,
+    excluded_chains: list[str] | None = None,
 ):
-    chains = goldsky_mainnet_chains()
+    all_chains = goldsky_mainnet_chains()
+
+    chains = []
+    excluded_chains = excluded_chains or []
+    for chain in all_chains:
+        if chain not in excluded_chains:
+            chains.append(chain)
 
     if dryrun:
         log.info("DRYRUN: No work will be done.")

--- a/src/op_analytics/datapipeline/etl/loadbq/main.py
+++ b/src/op_analytics/datapipeline/etl/loadbq/main.py
@@ -48,4 +48,5 @@ def load_superchain_4337_to_bq(
         dryrun=dryrun,
         force_complete=force_complete,
         force_not_ready=force_not_ready,
+        excluded_chains=["kroma"],
     )


### PR DESCRIPTION
Fix issue with load bq tasks never being already complete. The complete_markers implementation was missing, so I added it. We now query the markers before preparing the task so we now if it was run before or not.

Update load bq so that chains can be excluded from loading. We found an issue with "kroma" not having traces and so we need to exclude it from the 4337 dataset.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
