### PR TITLE
Add audit for trace counts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ sphinx-serve: .makemarkers/sphinx-docs
 #     DOCKER IMAGE
 # ----------------------------------------------------------------------------#
 
-IMAGE_TAG = ghcr.io/lithium323/op-analytics:v20250203.1
+IMAGE_TAG = ghcr.io/lithium323/op-analytics:v20250302.1
 IMAGE_TAG_DAGSTER = ghcr.io/lithium323/op-analytics-dagster:v20250228.001
 
 .PHONY: uv-build

--- a/k8s/ingestion.yaml
+++ b/k8s/ingestion.yaml
@@ -25,7 +25,7 @@ spec:
           containers:
           - name: python-runner-ingestion
             imagePullPolicy: IfNotPresent
-            image: ghcr.io/lithium323/op-analytics:v20250203.1
+            image: ghcr.io/lithium323/op-analytics:v20250302.1
             command: ["tini", "-v", "--", "opdata"]
             args: ["chains", "noargs_ingest"]
             env:

--- a/k8s/load-public-bq.yaml
+++ b/k8s/load-public-bq.yaml
@@ -17,7 +17,7 @@ spec:
           containers:
           - name: python-runner-public-bq
             imagePullPolicy: IfNotPresent
-            image: ghcr.io/lithium323/op-analytics:v20250203.1
+            image: ghcr.io/lithium323/op-analytics:v20250302.1
             command: ["tini", "-v", "--", "opdata"]
             args: ["chains", "noargs_public_bq"]
             env:

--- a/k8s/models-4337-backfill-pt2.yaml
+++ b/k8s/models-4337-backfill-pt2.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: python-runner-4337-backfill-pt2
         imagePullPolicy: Always
-        image: ghcr.io/lithium323/op-analytics:v20250203.1
+        image: ghcr.io/lithium323/op-analytics:v20250302.1
         command: ["tini", "-v", "--", "opdata"]
         args: ["chains", "aa_backfill_pt2"]
         env:

--- a/k8s/models-blockbatch.yaml
+++ b/k8s/models-blockbatch.yaml
@@ -25,7 +25,7 @@ spec:
           containers:
           - name: python-runner-blockbatch
             imagePullPolicy: IfNotPresent
-            image: ghcr.io/lithium323/op-analytics:v20250203.1
+            image: ghcr.io/lithium323/op-analytics:v20250302.1
             command: ["tini", "-v", "--", "opdata"]
             args: ["chains", "noargs_blockbatch"]
             env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "op-analytics"
-version = "20250203.1"
+version = "20250302.1"
 description = "Data analysis tools by OP Labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/op_analytics/datapipeline/etl/ingestion/main.py
+++ b/src/op_analytics/datapipeline/etl/ingestion/main.py
@@ -137,9 +137,14 @@ def auditor(task: IngestionTask):
     # Iterate over all the registered audits.
     # Raises an exception if an audit is failing.
     passing_audits = 0
+    skipped_audits = 0
     for name, audit in REGISTERED_AUDITS.items():
         # Execute the audit!
-        result: pl.DataFrame = audit(task.input_dataframes)
+        result: pl.DataFrame | None = audit(task.chain, task.input_dataframes)
+
+        if result is None:
+            skipped_audits += 1
+            continue
 
         if not result.collect_schema().get("audit_name") == pl.String:
             raise Exception("Audit result DataFrame is missing column: audit_name[String]")
@@ -158,7 +163,7 @@ def auditor(task: IngestionTask):
             else:
                 passing_audits += 1
 
-    log.info(f"audit {passing_audits} checks OK")
+    log.info(f"audits: {skipped_audits} skipped, {passing_audits} OK")
 
     # Default values for "chain" and "dt" to be used in cases where one of the
     # other datsets is empty.  On chains with very low throughput (e.g. race) we

--- a/uv.lock
+++ b/uv.lock
@@ -2259,7 +2259,7 @@ wheels = [
 
 [[package]]
 name = "op-analytics"
-version = "20250203.1"
+version = "20250302.1"
 source = { editable = "." }
 dependencies = [
     { name = "clickhouse-connect" },


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

For each block num_traces should be >= num_transactions. We did not have this
audit at ingestion so sometimes we would pass through blocks that were missing
traces.

This issue was discovered while working on AA 4337 datasets. On kroma we stopped
getting traces on 2024-02-11.

We want to continue ingesting Kroma so we added a special case in the new trace
count audit to let kroma always pass.

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
