### PR TITLE
Memory use improvements on aa-4337 model.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ sphinx-serve: .makemarkers/sphinx-docs
 #     DOCKER IMAGE
 # ----------------------------------------------------------------------------#
 
-IMAGE_TAG = ghcr.io/lithium323/op-analytics:v20250314.2
+IMAGE_TAG = ghcr.io/lithium323/op-analytics:v20250314.3
 IMAGE_TAG_DAGSTER = ghcr.io/lithium323/op-analytics-dagster:v20250314.004
 
 .PHONY: uv-build

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ sphinx-serve: .makemarkers/sphinx-docs
 #     DOCKER IMAGE
 # ----------------------------------------------------------------------------#
 
-IMAGE_TAG = ghcr.io/lithium323/op-analytics:v20250314.3
+IMAGE_TAG = ghcr.io/lithium323/op-analytics:v20250314.4
 IMAGE_TAG_DAGSTER = ghcr.io/lithium323/op-analytics-dagster:v20250314.004
 
 .PHONY: uv-build

--- a/k8s/ingestion.yaml
+++ b/k8s/ingestion.yaml
@@ -25,7 +25,7 @@ spec:
           containers:
           - name: python-runner-ingestion
             imagePullPolicy: IfNotPresent
-            image: ghcr.io/lithium323/op-analytics:v20250314.2
+            image: ghcr.io/lithium323/op-analytics:v20250314.3
             command: ["tini", "-v", "--", "opdata"]
             args: ["chains", "noargs_ingest"]
             env:

--- a/k8s/ingestion.yaml
+++ b/k8s/ingestion.yaml
@@ -25,7 +25,7 @@ spec:
           containers:
           - name: python-runner-ingestion
             imagePullPolicy: IfNotPresent
-            image: ghcr.io/lithium323/op-analytics:v20250314.3
+            image: ghcr.io/lithium323/op-analytics:v20250314.4
             command: ["tini", "-v", "--", "opdata"]
             args: ["chains", "noargs_ingest"]
             env:

--- a/k8s/load-public-bq.yaml
+++ b/k8s/load-public-bq.yaml
@@ -17,7 +17,7 @@ spec:
           containers:
           - name: python-runner-public-bq
             imagePullPolicy: IfNotPresent
-            image: ghcr.io/lithium323/op-analytics:v20250314.2
+            image: ghcr.io/lithium323/op-analytics:v20250314.3
             command: ["tini", "-v", "--", "opdata"]
             args: ["chains", "noargs_public_bq"]
             env:

--- a/k8s/load-public-bq.yaml
+++ b/k8s/load-public-bq.yaml
@@ -17,7 +17,7 @@ spec:
           containers:
           - name: python-runner-public-bq
             imagePullPolicy: IfNotPresent
-            image: ghcr.io/lithium323/op-analytics:v20250314.3
+            image: ghcr.io/lithium323/op-analytics:v20250314.4
             command: ["tini", "-v", "--", "opdata"]
             args: ["chains", "noargs_public_bq"]
             env:

--- a/k8s/models-4337-backfill-pt2.yaml
+++ b/k8s/models-4337-backfill-pt2.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: python-runner-4337-backfill-pt2
         imagePullPolicy: Always
-        image: ghcr.io/lithium323/op-analytics:v20250314.3
+        image: ghcr.io/lithium323/op-analytics:v20250314.4
         command: ["tini", "-v", "--", "opdata"]
         args: ["chains", "aa_backfill_pt2"]
         env:

--- a/k8s/models-4337-backfill-pt2.yaml
+++ b/k8s/models-4337-backfill-pt2.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: python-runner-4337-backfill-pt2
         imagePullPolicy: Always
-        image: ghcr.io/lithium323/op-analytics:v20250314.2
+        image: ghcr.io/lithium323/op-analytics:v20250314.3
         command: ["tini", "-v", "--", "opdata"]
         args: ["chains", "aa_backfill_pt2"]
         env:

--- a/k8s/models-fees-backfill.yaml
+++ b/k8s/models-fees-backfill.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: python-runner-fees-backfill
         imagePullPolicy: Always
-        image: ghcr.io/lithium323/op-analytics:v20250314.3
+        image: ghcr.io/lithium323/op-analytics:v20250314.4
         command: ["tini", "-v", "--", "opdata"]
         args: ["chains", "fees_backfill"]
         env:

--- a/k8s/models-fees-backfill.yaml
+++ b/k8s/models-fees-backfill.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: python-runner-fees-backfill
         imagePullPolicy: Always
-        image: ghcr.io/lithium323/op-analytics:v20250314.2
+        image: ghcr.io/lithium323/op-analytics:v20250314.3
         command: ["tini", "-v", "--", "opdata"]
         args: ["chains", "fees_backfill"]
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "op-analytics"
-version = "20250314.2"
+version = "20250314.3"
 description = "Data analysis tools by OP Labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "op-analytics"
-version = "20250314.3"
+version = "20250314.4"
 description = "Data analysis tools by OP Labs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/op_analytics/cli/subcommands/chains/app.py
+++ b/src/op_analytics/cli/subcommands/chains/app.py
@@ -289,8 +289,8 @@ def aa_backfill_pt2():
     num_indexes = 12
 
     # Define start and end dates for the backfill.
-    start_date = datetime.strptime("20241001", "%Y%m%d")
-    end_date = datetime.strptime("20241225", "%Y%m%d")
+    start_date = datetime.strptime("20241201", "%Y%m%d")
+    end_date = datetime.strptime("20250314", "%Y%m%d")
 
     # Generate date ranges with N-day intervals
     date_ranges = []

--- a/src/op_analytics/datapipeline/models/code/account_abstraction/model.py
+++ b/src/op_analytics/datapipeline/models/code/account_abstraction/model.py
@@ -1,5 +1,5 @@
 from op_analytics.coreutils.duckdb_inmem.client import DuckDBContext, ParquetData
-from op_analytics.coreutils.logger import structlog
+from op_analytics.coreutils.logger import memory_usage, structlog
 from op_analytics.datapipeline.models.code.account_abstraction.abis import (
     HANDLE_OPS_FUNCTION_METHOD_ID_v0_6_0,
     HANDLE_OPS_FUNCTION_METHOD_ID_v0_7_0,
@@ -49,17 +49,19 @@ def account_abstraction(
         },
     )
 
+    log.info("memory usage after user ops", max_rss=memory_usage())
+
     # Persist the prefiltered traces for performance gains.
     prefiltered_traces = input_datasets[
         "blockbatch/account_abstraction_prefilter/entrypoint_traces_v1"
-    ].create_table(
-        additional_sql="ORDER BY block_number, transaction_hash",
-    )
+    ].create_table()
+
+    log.info("memory usage after prefiltered", max_rss=memory_usage())
 
     # Traces initiated on behalf of the UserOperationEvent sender
     entrypoint_traces = auxiliary_templates[
         "account_abstraction/enriched_entrypoint_traces"
-    ].create_table(
+    ].create_view(
         duckdb_context=ctx,
         template_parameters={
             "prefiltered_traces": prefiltered_traces,
@@ -71,6 +73,8 @@ def account_abstraction(
         },
     )
 
+    log.info("memory usage after enriched traces", max_rss=memory_usage())
+
     # Data Quality Checks
     errors = []
     for name, val in auxiliary_templates.items():
@@ -80,6 +84,8 @@ def account_abstraction(
         raise Exception("\n\n".join([name] + [str(_) for _ in errors]))
     else:
         log.info("Data Quality OK")
+
+    log.info("memory usage after data quality", max_rss=memory_usage())
 
     return {
         "useroperationevent_logs_v2": user_ops,

--- a/uv.lock
+++ b/uv.lock
@@ -2341,7 +2341,7 @@ wheels = [
 
 [[package]]
 name = "op-analytics"
-version = "20250314.2"
+version = "20250314.3"
 source = { editable = "." }
 dependencies = [
     { name = "clickhouse-connect" },

--- a/uv.lock
+++ b/uv.lock
@@ -2341,7 +2341,7 @@ wheels = [
 
 [[package]]
 name = "op-analytics"
-version = "20250314.3"
+version = "20250314.4"
 source = { editable = "." }
 dependencies = [
     { name = "clickhouse-connect" },


### PR DESCRIPTION
Running a backfill up to 2024/10/01 and the larger batches we have for base around 2024/10 were running into memory issues.

Switching from a table to a view on the enriched traces (the final query in the model) and also removing the ORDER BY on the persisted filtered traces reduced memory use from 17GB -> 6GB.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
