### PR TITLE
Add dagster retries to more jobs to protect against slow kube node start up

### DIFF
--- a/src/op_analytics/dagster/defs.py
+++ b/src/op_analytics/dagster/defs.py
@@ -1,6 +1,5 @@
 from dagster import (
     AssetSelection,
-    DefaultScheduleStatus,
     Definitions,
     load_assets_from_modules,
 )
@@ -44,6 +43,22 @@ defs = Definitions(
     assets=ASSETS,
     schedules=[
         #
+        # Blockbatch Ingestion
+        create_schedule_for_selection(
+            job_name="blockbatch_ingest",
+            selection=AssetSelection.assets(
+                ["blockingest", "audit_and_ingest"],
+            ),
+            cron_schedule="8,38 * * * *",
+            custom_k8s_config=OPK8sConfig(
+                mem_request="6Gi",
+                mem_limit="8Gi",
+                cpu_request="1",
+                cpu_limit="1",
+            ),
+            num_retries=None,
+        ),
+        #
         # Blockbatch Models
         create_schedule_for_selection(
             job_name="blockbatch_models_a",
@@ -51,13 +66,13 @@ defs = Definitions(
                 ["blockbatch", "update_a"],
             ),
             cron_schedule="22,52 * * * *",
-            default_status=DefaultScheduleStatus.RUNNING,
             custom_k8s_config=OPK8sConfig(
                 mem_request="4Gi",
                 mem_limit="6Gi",
                 cpu_request="1",
                 cpu_limit="1",
             ),
+            num_retries=None,
         ),
         #
         # Blockbatch Models
@@ -67,29 +82,13 @@ defs = Definitions(
                 ["blockbatch", "update_b"],
             ),
             cron_schedule="7,37 * * * *",
-            default_status=DefaultScheduleStatus.RUNNING,
             custom_k8s_config=OPK8sConfig(
                 mem_request="4Gi",
                 mem_limit="6Gi",
                 cpu_request="1",
                 cpu_limit="1",
             ),
-        ),
-        #
-        # Blockbatch Models
-        create_schedule_for_selection(
-            job_name="blockbatch_ingest",
-            selection=AssetSelection.assets(
-                ["blockingest", "audit_and_ingest"],
-            ),
-            cron_schedule="8,38 * * * *",
-            default_status=DefaultScheduleStatus.RUNNING,
-            custom_k8s_config=OPK8sConfig(
-                mem_request="6Gi",
-                mem_limit="8Gi",
-                cpu_request="1",
-                cpu_limit="1",
-            ),
+            num_retries=None,
         ),
         #
         # Load superchain_raw to BQ
@@ -99,8 +98,8 @@ defs = Definitions(
                 ["bqpublic", "superchain_raw"],
             ),
             cron_schedule="2 4,16 * * *",
-            default_status=DefaultScheduleStatus.RUNNING,
             custom_k8s_config=SMALL_POD,
+            num_retries=None,
         ),
         #
         # Load superchain_4337 to BQ
@@ -110,15 +109,14 @@ defs = Definitions(
                 ["bqpublic", "superchain_4337"],
             ),
             cron_schedule="32 4,16 * * *",
-            default_status=DefaultScheduleStatus.RUNNING,
             custom_k8s_config=SMALL_POD,
+            num_retries=None,
         ),
         #
         # Chain related daily jobs
         create_schedule_for_group(
             group="chainsdaily",
             cron_schedule="0 3 * * *",  # Runs at 3 AM daily
-            default_status=DefaultScheduleStatus.RUNNING,
             custom_k8s_config=OPK8sConfig(
                 mem_request="720Mi",
                 mem_limit="2Gi",
@@ -129,7 +127,6 @@ defs = Definitions(
         create_schedule_for_group(
             group="chainshourly",
             cron_schedule="38 * * * *",  # Run every hour
-            default_status=DefaultScheduleStatus.RUNNING,
             custom_k8s_config=OPK8sConfig(
                 mem_request="720Mi",
                 mem_limit="2Gi",
@@ -143,13 +140,11 @@ defs = Definitions(
                 ["defillama", "protocol_tvl_flows_filtered"],
             ).upstream(),
             cron_schedule="0 12 * * *",
-            default_status=DefaultScheduleStatus.RUNNING,
             custom_k8s_config=OPK8sConfig(
                 mem_request="3Gi",
                 mem_limit="4Gi",
             ),
             k8s_pod_per_step=False,
-            job_tags={"dagster/max_retries": 3, "dagster/retry_strategy": "FROM_FAILURE"},
         ),
         #
         # Defillama Pools
@@ -160,13 +155,11 @@ defs = Definitions(
                 ["defillama", "lend_borrow_pools"],
             ).upstream(),
             cron_schedule="0 15 * * *",
-            default_status=DefaultScheduleStatus.RUNNING,
             custom_k8s_config=OPK8sConfig(
                 mem_request="3Gi",
                 mem_limit="4Gi",
             ),
             k8s_pod_per_step=False,
-            job_tags={"dagster/max_retries": 3, "dagster/retry_strategy": "FROM_FAILURE"},
         ),
         #
         # Defillama other
@@ -176,27 +169,23 @@ defs = Definitions(
                 ["defillama", "other"],
             ).upstream(),
             cron_schedule="0 14 * * *",
-            default_status=DefaultScheduleStatus.RUNNING,
             custom_k8s_config=SMALL_POD,
         ),
         #
         create_schedule_for_group(
             group="github",
             cron_schedule="0 2 * * *",  # Runs at 2 AM daily
-            default_status=DefaultScheduleStatus.RUNNING,
         ),
         #
         create_schedule_for_group(
             group="dune",
             # Runs at 8 AM daily.
             cron_schedule="0 8 * * *",
-            default_status=DefaultScheduleStatus.RUNNING,
         ),
         #
         create_schedule_for_group(
             group="governance",
             cron_schedule="0 10 * * *",
-            default_status=DefaultScheduleStatus.RUNNING,
             custom_k8s_config=SMALL_POD,
         ),
         #
@@ -204,14 +193,12 @@ defs = Definitions(
             group="growthepie",
             # GrowThePie is generally a little delayed in providing data for the previous day.
             cron_schedule="0 10 * * *",
-            default_status=DefaultScheduleStatus.RUNNING,
             custom_k8s_config=SMALL_POD,
         ),
         #
         create_schedule_for_group(
             group="l2beat",
             cron_schedule="0 8 * * *",
-            default_status=DefaultScheduleStatus.RUNNING,
             custom_k8s_config=SMALL_POD,
         ),
         #
@@ -221,7 +208,6 @@ defs = Definitions(
                 ["transforms", "teleportr"],
             ),
             cron_schedule="47 4,8,14,20 * * *",
-            default_status=DefaultScheduleStatus.RUNNING,
             custom_k8s_config=SMALL_POD,
         ),
         #
@@ -231,7 +217,6 @@ defs = Definitions(
                 ["transforms", "dune"],
             ),
             cron_schedule="47 4,8,14,20 * * *",
-            default_status=DefaultScheduleStatus.RUNNING,
             custom_k8s_config=SMALL_POD,
         ),
         #
@@ -242,7 +227,6 @@ defs = Definitions(
                 ["transforms", "interop"],
             ),
             cron_schedule="17 4,8,14,20 * * *",
-            default_status=DefaultScheduleStatus.RUNNING,
             custom_k8s_config=SMALL_POD,
         ),
         #
@@ -252,7 +236,6 @@ defs = Definitions(
                 ["transforms", "fees"],
             ),
             cron_schedule="7 4,8,14,20 * * *",
-            default_status=DefaultScheduleStatus.RUNNING,
             custom_k8s_config=SMALL_POD,
         ),
     ],

--- a/src/op_analytics/dagster/utils/jobs.py
+++ b/src/op_analytics/dagster/utils/jobs.py
@@ -52,23 +52,17 @@ def op_analytics_asset_selection_job(
 def create_schedule_for_group(
     group: str,
     cron_schedule: str,
-    default_status: DefaultScheduleStatus,
     custom_k8s_config: OPK8sConfig | None = None,
     k8s_pod_per_step: bool = False,
-    job_tags: dict[str, Any] | None = None,
+    num_retries: int | None = None,
 ):
-    return ScheduleDefinition(
-        name=group,
-        job=op_analytics_asset_selection_job(
-            job_name=f"{group}_job",
-            selection=AssetSelection.groups(group),
-            custom_k8s_config=custom_k8s_config,
-            k8s_pod_per_step=k8s_pod_per_step,
-            job_tags=job_tags,
-        ),
+    return create_schedule_for_selection(
+        job_name=f"{group}_job",
+        selection=AssetSelection.groups(group),
         cron_schedule=cron_schedule,
-        execution_timezone="UTC",
-        default_status=default_status,
+        custom_k8s_config=custom_k8s_config,
+        k8s_pod_per_step=k8s_pod_per_step,
+        num_retries=num_retries,
     )
 
 
@@ -76,11 +70,15 @@ def create_schedule_for_selection(
     job_name: str,
     selection: AssetSelection,
     cron_schedule: str,
-    default_status: DefaultScheduleStatus,
     custom_k8s_config: OPK8sConfig | None = None,
     k8s_pod_per_step: bool = False,
-    job_tags: dict[str, Any] | None = None,
+    num_retries: int | None = 3,
 ):
+    if num_retries is not None:
+        job_tags = {"dagster/max_retries": num_retries, "dagster/retry_strategy": "FROM_FAILURE"}
+    else:
+        job_tags = None
+
     return ScheduleDefinition(
         name=job_name,
         job=op_analytics_asset_selection_job(
@@ -92,7 +90,7 @@ def create_schedule_for_selection(
         ),
         cron_schedule=cron_schedule,
         execution_timezone="UTC",
-        default_status=default_status,
+        default_status=DefaultScheduleStatus.RUNNING,
     )
 
 


### PR DESCRIPTION


<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
