### PR TITLE
Use v2 table for interop export (v1 is now deprecated)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ sphinx-serve: .makemarkers/sphinx-docs
 IMAGE_TAG = ghcr.io/lithium323/op-analytics:v20250404.2
 
 # Dagster image version.
-IMAGE_TAG_DAGSTER = ghcr.io/lithium323/op-analytics-dagster:v20250407.001
+IMAGE_TAG_DAGSTER = ghcr.io/lithium323/op-analytics-dagster:v20250408.001
 
 
 .PHONY: uv-build

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -296,7 +296,7 @@ dagster-user-deployments:
       image:
         # When a tag is not supplied, it will default as the Helm chart version.
         repository: "ghcr.io/lithium323/op-analytics-dagster"
-        tag: "v20250407.001"
+        tag: "v20250408.001"
 
         # Change with caution! If you're using a fixed tag for pipeline run images, changing the
         # image pull policy to anything other than "Always" will use a cached/stale image, which is

--- a/src/op_analytics/transforms/interop/update/07_export_fact_erc20_create_traces_v1.sql
+++ b/src/op_analytics/transforms/interop/update/07_export_fact_erc20_create_traces_v1.sql
@@ -62,6 +62,6 @@ SELECT
   , (chain_id, contract_address) IN (ntt_tokens) AS has_ntt_events
 
 FROM
-  transforms_interop.fact_erc20_create_traces_v1 FINAL
+  transforms_interop.fact_erc20_create_traces_v2 FINAL
 WHERE
   dt >= '2024-10-01'


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
