### PR TITLE
Add distinct tx from and tx to - 01_agg_daily_transactions_grouping_sets

### DIFF
--- a/src/op_analytics/transforms/fees/create/01_agg_daily_transactions_grouping_sets.sql
+++ b/src/op_analytics/transforms/fees/create/01_agg_daily_transactions_grouping_sets.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS _placeholder_
     `count_transactions` UInt64,
     `count_success_transactions` UInt64,
     `distinct_blocks` UInt64,
+    `distinct_tx_from_address` UInt64,
     
     `sum_l2_gas_used` UInt64,
     `sum_success_l2_gas_used` UInt64,

--- a/src/op_analytics/transforms/fees/create/01_agg_daily_transactions_grouping_sets.sql
+++ b/src/op_analytics/transforms/fees/create/01_agg_daily_transactions_grouping_sets.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS _placeholder_
     `count_transactions` UInt64,
     `count_success_transactions` UInt64,
     `distinct_blocks` UInt64,
+    `distinct_tx_to_address` UInt64,
     `distinct_tx_from_address` UInt64,
     
     `sum_l2_gas_used` UInt64,

--- a/src/op_analytics/transforms/fees/create/02_agg_daily_transactions.sql
+++ b/src/op_analytics/transforms/fees/create/02_agg_daily_transactions.sql
@@ -8,6 +8,8 @@ CREATE TABLE IF NOT EXISTS _placeholder_
     `count_transactions` UInt64,
     `count_success_transactions` UInt64,
     `distinct_blocks` UInt64,
+    `distinct_tx_to_address` UInt64,
+    `distinct_tx_from_address` UInt64,
     
     `sum_l2_gas_used` UInt64,
     `sum_success_l2_gas_used` UInt64,

--- a/src/op_analytics/transforms/fees/update/01_agg_daily_transactions_grouping_sets.sql
+++ b/src/op_analytics/transforms/fees/update/01_agg_daily_transactions_grouping_sets.sql
@@ -99,6 +99,7 @@ SELECT
   , count_transactions
   , count_success_transactions
   , distinct_blocks
+  , distinct_tx_to_address
   , distinct_tx_from_address
 
   -- Gas Usage

--- a/src/op_analytics/transforms/fees/update/01_agg_daily_transactions_grouping_sets.sql
+++ b/src/op_analytics/transforms/fees/update/01_agg_daily_transactions_grouping_sets.sql
@@ -25,6 +25,8 @@ WITH aggregates AS (
     , countIf(success) AS count_success_transactions
 
     , COUNT(DISTINCT block_number) AS distinct_blocks
+    , COUNT(DISTINCT to_address) AS distinct_tx_to_address
+    , COUNT(DISTINCT from_address) AS distinct_tx_from_address
 
     , SUM(l2_gas_used) AS sum_l2_gas_used
     , sumIf(l2_gas_used, success) AS sum_success_l2_gas_used
@@ -97,6 +99,7 @@ SELECT
   , count_transactions
   , count_success_transactions
   , distinct_blocks
+  , distinct_tx_from_address
 
   -- Gas Usage
   , sum_l2_gas_used

--- a/src/op_analytics/transforms/fees/update/02_agg_daily_transactions.sql
+++ b/src/op_analytics/transforms/fees/update/02_agg_daily_transactions.sql
@@ -9,6 +9,8 @@ SELECT
   , count_transactions
   , count_success_transactions
   , distinct_blocks
+  , distinct_tx_to_address
+  , distinct_tx_from_address
 
   -- Gas Usage
   , sum_l2_gas_used


### PR DESCRIPTION
Adds count of distinct tx from, which is used in custom bot contract identification logic. Also added distinct tx to for comprehensiveness.

Note that these will be 1, when they're included in the grouping set (i.e. if we group by to address, then distinct to address = 1). These counts are really only useful when the field that we count distinct for is not in the grouping set (i.e. we use distinct tx from in the `(dt, chain, chain_id, network, to_address)` group and below.