### PR TITLE
ChainMetadataAggregator Integration

### DIFF
--- a/src/op_analytics/dagster/assets/chain_metadata.py
+++ b/src/op_analytics/dagster/assets/chain_metadata.py
@@ -1,0 +1,38 @@
+from dagster import AssetExecutionContext, Config, asset
+from pydantic import Field
+
+from op_analytics.coreutils.logger import structlog
+from op_analytics.datapipeline.chains.aggregator import build_all_chains_metadata
+
+log = structlog.get_logger()
+
+
+class ChainMetadataConfig(Config):
+    output_bq_table: str = Field(
+        description="Target BigQuery table name for aggregated metadata output"
+    )
+    manual_mappings_filepath: str = Field(description="Path to manual mappings configuration file")
+    bq_project_id: str = Field(description="BigQuery project ID for data operations")
+    bq_dataset_id: str = Field(description="BigQuery dataset ID for table operations")
+
+
+@asset
+def all_chains_metadata_asset(context: AssetExecutionContext, config: ChainMetadataConfig):
+    log.info("Chain metadata aggregation asset started")
+
+    log.info(
+        "Asset configuration",
+        output_bq_table=config.output_bq_table,
+        manual_mappings_filepath=config.manual_mappings_filepath,
+        bq_project_id=config.bq_project_id,
+        bq_dataset_id=config.bq_dataset_id,
+    )
+
+    build_all_chains_metadata(
+        output_bq_table=config.output_bq_table,
+        manual_mappings_filepath=config.manual_mappings_filepath,
+        bq_project_id=config.bq_project_id,
+        bq_dataset_id=config.bq_dataset_id,
+    )
+
+    log.info("Chain metadata aggregation asset completed successfully")

--- a/src/op_analytics/dagster/defs.py
+++ b/src/op_analytics/dagster/defs.py
@@ -19,6 +19,7 @@ MODULE_NAMES = [
     "blockbatchloaddaily",
     "bqpublic",
     "chainsdaily",
+    "chain_metadata",
     "defillama",
     "dune",
     "github",

--- a/src/op_analytics/datapipeline/chains/aggregator.py
+++ b/src/op_analytics/datapipeline/chains/aggregator.py
@@ -1,0 +1,62 @@
+"""
+ChainMetadataAggregator module for op_analytics.datapipeline.chains.
+
+This module provides functionality to aggregate and process metadata from multiple chains,
+performing entity resolution, deduplication, and enrichment before outputting to BigQuery.
+"""
+
+from op_analytics.coreutils.logger import structlog
+
+log = structlog.get_logger()
+
+
+def build_all_chains_metadata(
+    output_bq_table: str,
+    manual_mappings_filepath: str,
+    bq_project_id: str,
+    bq_dataset_id: str,
+) -> None:
+    """
+    Build aggregated metadata for all chains with comprehensive processing pipeline.
+
+    This function orchestrates the complete chain metadata aggregation pipeline,
+    including data loading, preprocessing, entity resolution, deduplication,
+    enrichment, and output to BigQuery.
+
+    Args:
+        output_bq_table (str): Target BigQuery table name for aggregated metadata
+        manual_mappings_filepath (str): Path to manual mappings configuration file
+        bq_project_id (str): BigQuery project ID for data operations
+        bq_dataset_id (str): BigQuery dataset ID for table operations
+
+    Returns:
+        None
+    """
+    log.info("Pipeline execution started")
+
+    log.info(
+        "Pipeline configuration parameters",
+        output_bq_table=output_bq_table,
+        manual_mappings_filepath=manual_mappings_filepath,
+        bq_project_id=bq_project_id,
+        bq_dataset_id=bq_dataset_id,
+    )
+
+    log.info("Step 1: Load Data - Not yet implemented")
+    log.info("Step 2: Combine - Not yet implemented")
+    log.info("Step 3: Preprocess - Not yet implemented")
+    log.info("Step 4: Entity Resolution - Not yet implemented")
+    log.info("Step 5: Deduplication - Not yet implemented")
+    log.info("Step 6: Enrichment - Not yet implemented")
+    log.info("Step 7: Output - Not yet implemented")
+
+    log.info("Pipeline execution finished")
+
+
+if __name__ == "__main__":
+    build_all_chains_metadata(
+        output_bq_table="aggregated_chains_metadata",
+        manual_mappings_filepath="config/manual_mappings.json",
+        bq_project_id="op-analytics-dev",
+        bq_dataset_id="chains_metadata",
+    )

--- a/src/op_analytics/datapipeline/chains/aggregator.py
+++ b/src/op_analytics/datapipeline/chains/aggregator.py
@@ -42,18 +42,82 @@ def build_all_chains_metadata(
         bq_dataset_id=bq_dataset_id,
     )
 
+    # TODO: Implement the following pipeline steps:
+
+    # Step 1: Load Data
+    # Intent: Load chain metadata from multiple BigQuery data sources:
+    # - op_stack_chain_metadata from api_table_uploads (OP Labs source, source_rank=1)
+    # - Goldsky chain usage data from daily_aggegate_l2_chain_usage_goldsky (OP Labs source, source_rank=1)
+    # - L2Beat activity data from daily_l2beat_l2_activity (L2Beat source, source_rank=2)
+    # - L2Beat metadata extended from l2beat_metadata_extended (L2Beat source, source_rank=1.9)
+    # - GrowThePie activity data from daily_growthepie_l2_activity (GrowThePie source, source_rank=3)
+    # - Dune transaction data from dune_all_txs (Dune source, source_rank=4.5)
+    # - DefiLlama chain TVL data from daily_defillama_chain_tvl (DefiLlama source, source_rank=5)
+    # - Manual mappings CSV file for known corrections/overrides
+    # Each source loader should return standardized DataFrames with consistent columns
     log.info("Step 1: Load Data - Not yet implemented")
+
+    # Step 2: Combine
+    # Intent: Concatenate all source DataFrames into a single unified dataset:
+    # - Union all source_dfs into all_sources_df using pd.concat()
+    # - Ensure consistent schema across all sources before concatenation
+    # - Log total records combined from all sources
+    # - This creates the raw comprehensive dataset for further processing
     log.info("Step 2: Combine - Not yet implemented")
+
+    # Step 3: Preprocess
+    # Intent: Clean and standardize the combined data with key transformations:
+    # - Generate chain_key column (hash of chain_name for grouping similar names)
+    # - Standardize chain_id column (ensure consistent format, handle special cases)
+    # - Apply data type conversions and handle missing values
+    # - Normalize chain names, symbols for consistency
+    # - This prepares data for entity resolution and grouping
     log.info("Step 3: Preprocess - Not yet implemented")
+
+    # Step 4: Entity Resolution
+    # Intent: Generate unified_key and apply manual mappings before grouping:
+    # - Create unified_key column combining chain_id, chain_key, and display_name logic
+    # - Apply manual mappings to correct data inconsistencies (e.g., chain_id overrides)
+    # - Handle special cases like 'molten' chain_id corrections based on source
+    # - This creates canonical identifiers for grouping duplicate entities
+    # - Manual mappings are applied BEFORE grouping to ensure correct entity resolution
     log.info("Step 4: Entity Resolution - Not yet implemented")
+
+    # Step 5: Deduplication
+    # Intent: Group by unified_key and merge attributes using source prioritization:
+    # - Group records by unified_key (represents same chain entity)
+    # - Within each group, sort by source_rank (lower rank = higher priority)
+    # - Select primary record from highest priority source
+    # - Aggregate fields: min_dt_day (min), max_dt_day (max), data_sources (concat), all_chain_keys (concat)
+    # - Apply secondary deduplication using is_dupe logic for remaining duplicates
+    # - Results in one canonical record per unique chain
     log.info("Step 5: Deduplication - Not yet implemented")
+
+    # Step 6: Enrichment
+    # Intent: Enhance deduplicated data with op_stack_chain_metadata enrichment:
+    # - Load op_stack_chain_metadata specifically for enrichment (not as competing source)
+    # - Left join with deduplicated data on chain_id (handle Celo -l2 suffix matching)
+    # - Coalesce/add fields: gas_token, da_layer, public_mainnet_launch_date, etc.
+    # - Calculate derived fields: provider_entity_w_superchain, eth_eco_l2l3, etc.
+    # - Apply business logic overrides (e.g., Celo max_dt_day correction)
+    # - Finalize all_chain_keys field aggregation
     log.info("Step 6: Enrichment - Not yet implemented")
+
+    # Step 7: Output
+    # Intent: Write the final enriched and deduplicated metadata to BigQuery:
+    # - Format final DataFrame according to target BigQuery schema requirements
+    # - Validate data quality and completeness before writing
+    # - Write to specified BigQuery table using write_full_df_to_bq with if_exists='replace'
+    # - Log success/failure status and record counts
+    # - Update processing metadata and create audit logs
     log.info("Step 7: Output - Not yet implemented")
 
     log.info("Pipeline execution finished")
 
 
 if __name__ == "__main__":
+    # Example usage with placeholder values
+    # In production, these would come from command line arguments or configuration
     build_all_chains_metadata(
         output_bq_table="aggregated_chains_metadata",
         manual_mappings_filepath="config/manual_mappings.json",


### PR DESCRIPTION
This is the first PR for the Total Crypto metadata integration. It provides the appropriate structure to base further additions and allows for smaller follow up PRs.

Additions:
- Created pipeline: build_all_chains_metadata() with 7 processing steps
- Dagster asset: all_chains_metadata_asset with config schema
- Config fields: output_bq_table, manual_mappings_filepath, bq_project_id, bq_dataset_id
- CLI command: build-metadata under opdata chains
- Registered Dagster asset module in defs.py