### PR TITLE
Ggarner/20250720/reorder schema column order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ sphinx-serve: .makemarkers/sphinx-docs
 IMAGE_TAG = ghcr.io/ethereum-optimism/op-analytics:v20250404.2
 
 # Dagster image version.
-IMAGE_TAG_DAGSTER = ghcr.io/ethereum-optimism/op-analytics-dagster:v20250720.001
+IMAGE_TAG_DAGSTER = ghcr.io/ethereum-optimism/op-analytics-dagster:v20250720.002
 
 
 .PHONY: uv-build

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -296,7 +296,7 @@ dagster-user-deployments:
       image:
         # When a tag is not supplied, it will default as the Helm chart version.
         repository: "ghcr.io/ethereum-optimism/op-analytics-dagster"
-        tag: "v20250720.001"
+        tag: "v20250720.002"
 
         # Change with caution! If you're using a fixed tag for pipeline run images, changing the
         # image pull policy to anything other than "Always" will use a cached/stale image, which is

--- a/src/op_analytics/datasources/chainsmeta/superchain/addresslist.py
+++ b/src/op_analytics/datasources/chainsmeta/superchain/addresslist.py
@@ -81,6 +81,14 @@ def pull_superchain_address_list() -> SuperchainAddressList:
     # Flatten the schema and convert to snake case.
     address_list_df = process_metadata_pull(address_list_raw_df)
 
+    # Get the column names from the schema, we don't need to worry about missing columns
+    # as schema validation will catch that later
+    schema_columns = list(SUPERCHAIN_ADDRESS_LIST_SCHEMA.keys())
+
+    # Reorder columns that exist in the dataframe according to schema order
+    existing_columns = [col for col in schema_columns if col in address_list_df.columns]
+    address_list_df = address_list_df.select(existing_columns)
+
     # Check the final schema is as expected. If something changes upstream the
     # exception will warn us.
     raise_for_schema_mismatch(


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Order of columns changed, just putting in a fix to reorder columns relative to expected schema and but skip if a column is not present. This causes order of the response from the RPC to not matter, but we will still fail if there are real schema mismatches.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
