### PR TITLE
[HOTFIX]Add BQ upload for chain metadata to Dagster pipeline

### DIFF
--- a/src/op_analytics/coreutils/bigquery/load.py
+++ b/src/op_analytics/coreutils/bigquery/load.py
@@ -153,7 +153,7 @@ def _destination_table_exists(client: bigquery.Client, table_fq: str) -> bool:
 
 def _build_parquet_load_job_config(
     *,
-    write_disposition: bigquery.WriteDisposition,
+    write_disposition: str,
     source_uri_prefix: str,
     time_partition_field: str,
     clustering_fields: list[str] | None,

--- a/src/op_analytics/coreutils/bigquery/load.py
+++ b/src/op_analytics/coreutils/bigquery/load.py
@@ -59,11 +59,7 @@ def _safe_qualify_destination(
     oplabs_env = os.getenv(OPLABS_ENVVAR, "").strip().lower()
     is_prod_env = oplabs_env in PROD_ENVS
 
-    legacy_override = os.getenv(ALLOW_PROD_WRITES_ENVVAR, "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-    }
+    legacy_override = os.getenv(ALLOW_PROD_WRITES_ENVVAR, "").strip().lower() in {"1", "true", "yes"}
 
     permitted = is_prod_env or allow_prod_writes or legacy_override
 
@@ -126,7 +122,6 @@ def _extract_failed_uris(exc: Exception, source_uris: list[str]) -> list[str]:
 # -----------------------------
 # Hive partitioning + job config
 # -----------------------------
-
 
 def _normalize_source_uri_prefix(prefix: str) -> str:
     p = prefix.strip()
@@ -202,7 +197,6 @@ def _run_parquet_load_job(
 # Partition clearing (rare fallback)
 # -----------------------------
 
-
 def _clear_partition_by_query(
     *,
     client: bigquery.Client,
@@ -231,7 +225,6 @@ def _clear_partition_by_query(
 # -----------------------------
 # Slow-path patching
 # -----------------------------
-
 
 @dataclass(frozen=True)
 class HiveParts:
@@ -340,7 +333,7 @@ def _append_parquet_uri_via_file_upload(
     storage_client: storage.Client,
     parquet_uri: str,
     destination_partition: str,  # project.dataset.table$YYYYMMDD
-    destination_table: str,  # project.dataset.table
+    destination_table: str,      # project.dataset.table
     date_partition: date,
     time_partition_field: str,
     rewrite_page_size: int = 256 * 1024,
@@ -394,11 +387,7 @@ def _append_parquet_uri_via_file_upload(
 
         except Exception as exc:
             # last resort
-            log.warning(
-                "Slow-path upload failed; falling back to dataframe append",
-                uri=parquet_uri,
-                error=str(exc),
-            )
+            log.warning("Slow-path upload failed; falling back to dataframe append", uri=parquet_uri, error=str(exc))
             _append_parquet_uri_rowwise(
                 client=client,
                 storage_client=storage_client,
@@ -429,9 +418,7 @@ def _append_parquet_uri_rowwise(
     time_partition_field: str,
     batch_rows: int = 25_000,
 ) -> None:
-    log.warning(
-        "Manual patch start (dataframe append)", uri=parquet_uri, destination=destination_partition
-    )
+    log.warning("Manual patch start (dataframe append)", uri=parquet_uri, destination=destination_partition)
 
     import pyarrow as pa
     import pyarrow.parquet as pq
@@ -466,9 +453,7 @@ def _append_parquet_uri_rowwise(
             for col, val in extra_cols.items():
                 df[col] = val
 
-            client.load_table_from_dataframe(
-                df, destination_partition, job_config=job_config
-            ).result()
+            client.load_table_from_dataframe(df, destination_partition, job_config=job_config).result()
             loaded += len(df)
 
         log.warning("Manual patch complete", uri=parquet_uri, rows_loaded=loaded, batches=batches)
@@ -483,7 +468,6 @@ def _append_parquet_uri_rowwise(
 # -----------------------------
 # Fast-path retry loop (the core change)
 # -----------------------------
-
 
 def _truncate_load_failfast_retry(
     *,
@@ -564,7 +548,6 @@ def _truncate_load_failfast_retry(
 # Public API
 # -----------------------------
 
-
 def load_from_parquet_uris(
     source_uris: list[str],
     source_uri_prefix: str,
@@ -600,15 +583,11 @@ def load_from_parquet_uris(
             clustering_fields=clustering_fields,
             destination_exists=False,
         )
-        client.load_table_from_uri(
-            source_uris=source_uris, destination=destination_partition, job_config=job_config
-        ).result()
+        client.load_table_from_uri(source_uris=source_uris, destination=destination_partition, job_config=job_config).result()
         log.info("DRYRUN WRITE_TRUNCATE to BQ", destination=destination_partition)
         return
 
-    destination_fq = _safe_qualify_destination(
-        client, destination, allow_prod_writes=allow_prod_writes
-    )
+    destination_fq = _safe_qualify_destination(client, destination, allow_prod_writes=allow_prod_writes)
     destination_exists = _destination_table_exists(client, destination_fq)
 
     date_suffix = date_partition.strftime("%Y%m%d")
@@ -702,9 +681,7 @@ def load_unpartitioned_single_uri(
             write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
             clustering_fields=clustering_fields,
         )
-        client.load_table_from_uri(
-            source_uris=[source_uri], destination=destination, job_config=job_config
-        ).result()
+        client.load_table_from_uri(source_uris=[source_uri], destination=destination, job_config=job_config).result()
         log.info("DRYRUN WRITE_TRUNCATE to BQ", destination=destination)
         return
 
@@ -718,7 +695,5 @@ def load_unpartitioned_single_uri(
         write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
     )
 
-    client.load_table_from_uri(
-        source_uris=[source_uri], destination=destination_fq, job_config=job_config
-    ).result()
+    client.load_table_from_uri(source_uris=[source_uri], destination=destination_fq, job_config=job_config).result()
     log.info("WRITE_TRUNCATE to BQ", destination=destination_fq)

--- a/src/op_analytics/coreutils/bigquery/load.py
+++ b/src/op_analytics/coreutils/bigquery/load.py
@@ -59,7 +59,11 @@ def _safe_qualify_destination(
     oplabs_env = os.getenv(OPLABS_ENVVAR, "").strip().lower()
     is_prod_env = oplabs_env in PROD_ENVS
 
-    legacy_override = os.getenv(ALLOW_PROD_WRITES_ENVVAR, "").strip().lower() in {"1", "true", "yes"}
+    legacy_override = os.getenv(ALLOW_PROD_WRITES_ENVVAR, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
 
     permitted = is_prod_env or allow_prod_writes or legacy_override
 
@@ -123,6 +127,7 @@ def _extract_failed_uris(exc: Exception, source_uris: list[str]) -> list[str]:
 # Hive partitioning + job config
 # -----------------------------
 
+
 def _normalize_source_uri_prefix(prefix: str) -> str:
     p = prefix.strip()
     if not p.endswith("/"):
@@ -153,7 +158,7 @@ def _destination_table_exists(client: bigquery.Client, table_fq: str) -> bool:
 
 def _build_parquet_load_job_config(
     *,
-    write_disposition: bigquery.WriteDisposition,
+    write_disposition: str,
     source_uri_prefix: str,
     time_partition_field: str,
     clustering_fields: list[str] | None,
@@ -197,6 +202,7 @@ def _run_parquet_load_job(
 # Partition clearing (rare fallback)
 # -----------------------------
 
+
 def _clear_partition_by_query(
     *,
     client: bigquery.Client,
@@ -225,6 +231,7 @@ def _clear_partition_by_query(
 # -----------------------------
 # Slow-path patching
 # -----------------------------
+
 
 @dataclass(frozen=True)
 class HiveParts:
@@ -333,7 +340,7 @@ def _append_parquet_uri_via_file_upload(
     storage_client: storage.Client,
     parquet_uri: str,
     destination_partition: str,  # project.dataset.table$YYYYMMDD
-    destination_table: str,      # project.dataset.table
+    destination_table: str,  # project.dataset.table
     date_partition: date,
     time_partition_field: str,
     rewrite_page_size: int = 256 * 1024,
@@ -387,7 +394,11 @@ def _append_parquet_uri_via_file_upload(
 
         except Exception as exc:
             # last resort
-            log.warning("Slow-path upload failed; falling back to dataframe append", uri=parquet_uri, error=str(exc))
+            log.warning(
+                "Slow-path upload failed; falling back to dataframe append",
+                uri=parquet_uri,
+                error=str(exc),
+            )
             _append_parquet_uri_rowwise(
                 client=client,
                 storage_client=storage_client,
@@ -418,7 +429,9 @@ def _append_parquet_uri_rowwise(
     time_partition_field: str,
     batch_rows: int = 25_000,
 ) -> None:
-    log.warning("Manual patch start (dataframe append)", uri=parquet_uri, destination=destination_partition)
+    log.warning(
+        "Manual patch start (dataframe append)", uri=parquet_uri, destination=destination_partition
+    )
 
     import pyarrow as pa
     import pyarrow.parquet as pq
@@ -453,7 +466,9 @@ def _append_parquet_uri_rowwise(
             for col, val in extra_cols.items():
                 df[col] = val
 
-            client.load_table_from_dataframe(df, destination_partition, job_config=job_config).result()
+            client.load_table_from_dataframe(
+                df, destination_partition, job_config=job_config
+            ).result()
             loaded += len(df)
 
         log.warning("Manual patch complete", uri=parquet_uri, rows_loaded=loaded, batches=batches)
@@ -468,6 +483,7 @@ def _append_parquet_uri_rowwise(
 # -----------------------------
 # Fast-path retry loop (the core change)
 # -----------------------------
+
 
 def _truncate_load_failfast_retry(
     *,
@@ -548,6 +564,7 @@ def _truncate_load_failfast_retry(
 # Public API
 # -----------------------------
 
+
 def load_from_parquet_uris(
     source_uris: list[str],
     source_uri_prefix: str,
@@ -583,11 +600,15 @@ def load_from_parquet_uris(
             clustering_fields=clustering_fields,
             destination_exists=False,
         )
-        client.load_table_from_uri(source_uris=source_uris, destination=destination_partition, job_config=job_config).result()
+        client.load_table_from_uri(
+            source_uris=source_uris, destination=destination_partition, job_config=job_config
+        ).result()
         log.info("DRYRUN WRITE_TRUNCATE to BQ", destination=destination_partition)
         return
 
-    destination_fq = _safe_qualify_destination(client, destination, allow_prod_writes=allow_prod_writes)
+    destination_fq = _safe_qualify_destination(
+        client, destination, allow_prod_writes=allow_prod_writes
+    )
     destination_exists = _destination_table_exists(client, destination_fq)
 
     date_suffix = date_partition.strftime("%Y%m%d")
@@ -681,7 +702,9 @@ def load_unpartitioned_single_uri(
             write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
             clustering_fields=clustering_fields,
         )
-        client.load_table_from_uri(source_uris=[source_uri], destination=destination, job_config=job_config).result()
+        client.load_table_from_uri(
+            source_uris=[source_uri], destination=destination, job_config=job_config
+        ).result()
         log.info("DRYRUN WRITE_TRUNCATE to BQ", destination=destination)
         return
 
@@ -695,5 +718,7 @@ def load_unpartitioned_single_uri(
         write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
     )
 
-    client.load_table_from_uri(source_uris=[source_uri], destination=destination_fq, job_config=job_config).result()
+    client.load_table_from_uri(
+        source_uris=[source_uri], destination=destination_fq, job_config=job_config
+    ).result()
     log.info("WRITE_TRUNCATE to BQ", destination=destination_fq)

--- a/src/op_analytics/coreutils/bigquery/load.py
+++ b/src/op_analytics/coreutils/bigquery/load.py
@@ -158,7 +158,7 @@ def _destination_table_exists(client: bigquery.Client, table_fq: str) -> bool:
 
 def _build_parquet_load_job_config(
     *,
-    write_disposition: str,
+    write_disposition: bigquery.WriteDisposition,
     source_uri_prefix: str,
     time_partition_field: str,
     clustering_fields: list[str] | None,

--- a/src/op_analytics/dagster/assets/chainsdaily.py
+++ b/src/op_analytics/dagster/assets/chainsdaily.py
@@ -11,8 +11,7 @@ def chain_metadata(context: OpExecutionContext):
     - Upload chain_metadata_raw.csv to Google Sheets.
     - Update the OP Analytics Chain Metadata [ADMIN MANAGED] google sheet.
     - Update the Across Superchain Bridge Addresses [ADMIN MANAGED] google sheet.
-
-    TODO: Decide if we want to upload to Dune, Clickhouse, BigQuery. or op-analytics-static repo.
+    - Upload chain metadata to BigQuery (api_table_uploads.op_stack_chain_metadata).
     """
     from op_analytics.datapipeline.chains.upload import upload_all
 

--- a/src/op_analytics/datapipeline/chains/upload.py
+++ b/src/op_analytics/datapipeline/chains/upload.py
@@ -2,13 +2,18 @@ import pandas as pd
 import polars as pl
 
 from op_analytics.coreutils.gsheets import record_changes, update_gsheet
+from op_analytics.coreutils.logger import structlog
 from op_analytics.coreutils.partitioned.dailydata import DEFAULT_DT
 
 from .across_bridge import load_across_bridge_addresses, upload_across_bridge_addresses
 from .goldsky_chains import goldsky_mainnet_chains_df
 from .load import load_chain_metadata
 
+log = structlog.get_logger()
+
 GSHEET_NAME = "chain_metadata"
+BQ_DATASET = "api_table_uploads"
+BQ_TABLE = "op_stack_chain_metadata"
 
 WORKSHEET_METADATA = "Chain Metadata"
 WORKSHEET_GOLDSKY_CHAINS = "Goldsky Chains"
@@ -42,6 +47,16 @@ def upload_all():
     ChainsMeta.CHAIN_METADATA_GSHEET.write(clean_df.with_columns(dt=pl.lit(DEFAULT_DT)))
     work_done.append(f"Uploaded to GCS: {ChainsMeta.CHAIN_METADATA_GSHEET.table}")
 
+    # Upload clean_df to BigQuery.
+    # Convert to pandas for the BQ write to match the legacy schema expected by
+    # downstream views (e.g. views.all_chains_metadata):
+    # - mainnet_chain_id: STRING (legacy used convert_to_int_or_keep_string)
+    # - date columns: DATETIME (pandas datetime64 → BQ DATETIME, not TIMESTAMP)
+    # - block_time_sec: FLOAT64 (keep as-is)
+    bq_df = _to_bq_pandas(clean_df)
+    _upload_pandas_to_bq(bq_df, BQ_DATASET, BQ_TABLE)
+    work_done.append(f"Uploaded to BQ: {BQ_DATASET}.{BQ_TABLE}")
+
     # Save a record of what was done.
     record_changes(GSHEET_NAME, messages=work_done)
 
@@ -55,6 +70,76 @@ def upload_all():
 
     # Store across_bridge_df as DailyData on GCS.
     ChainsMeta.ACROSS_BRIDGE_GSHEET.write(across_bridge_df.with_columns(dt=pl.lit(DEFAULT_DT)))
+
+
+_BQ_DATE_COLS = [
+    "public_mainnet_launch_date",
+    "op_chain_start",
+    "op_governed_start",
+    "migration_start",
+]
+
+
+def _to_bq_pandas(clean_df: pl.DataFrame) -> pd.DataFrame:
+    """Convert clean Polars df to a pandas df matching the legacy BQ schema.
+
+    Uses pandas so that timezone-naive datetimes map to BQ DATETIME (not TIMESTAMP).
+    """
+    pdf = clean_df.to_pandas()
+    pdf["mainnet_chain_id"] = pdf["mainnet_chain_id"].astype("Int64").astype("string")
+    for col in _BQ_DATE_COLS:
+        if col in pdf.columns:
+            pdf[col] = pd.to_datetime(pdf[col], errors="coerce")
+    return pdf
+
+
+def _upload_pandas_to_bq(pdf: pd.DataFrame, dataset: str, table_name: str):
+    """Write a pandas DataFrame to BQ, using CSV format to preserve DATETIME types.
+
+    We use CSV instead of Parquet because BQ interprets Parquet timestamps as TIMESTAMP
+    (with timezone), but the legacy schema uses DATETIME (without timezone). CSV + explicit
+    schema gives us full control over BQ column types.
+    """
+    import io
+
+    from google.cloud import bigquery
+
+    from op_analytics.coreutils.bigquery.client import init_client
+    from op_analytics.coreutils.logger import human_rows, human_size
+
+    client = init_client()
+    destination = f"{dataset}.{table_name}"
+
+    # Build BQ schema: use DATETIME for date columns, infer the rest.
+    bq_schema = []
+    for col in pdf.columns:
+        if col in _BQ_DATE_COLS:
+            bq_schema.append(bigquery.SchemaField(col, "DATETIME"))
+        elif pdf[col].dtype == "float64":
+            bq_schema.append(bigquery.SchemaField(col, "FLOAT64"))
+        elif pdf[col].dtype == "bool":
+            bq_schema.append(bigquery.SchemaField(col, "BOOLEAN"))
+        else:
+            bq_schema.append(bigquery.SchemaField(col, "STRING"))
+
+    with io.BytesIO() as stream:
+        pdf.to_csv(stream, index=False)
+        filesize = stream.tell()
+        stream.seek(0)
+        job = client.load_table_from_file(
+            stream,
+            destination=destination,
+            job_config=bigquery.LoadJobConfig(
+                source_format=bigquery.SourceFormat.CSV,
+                skip_leading_rows=1,
+                schema=bq_schema,
+                write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+            ),
+        )
+        job.result()
+        log.info(
+            f"WRITE_TRUNCATE: Wrote {human_rows(len(pdf))} {human_size(filesize)} to BQ {destination}"
+        )
 
 
 def to_pandas(clean_df: pl.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
The Dagster chain_metadata asset was uploading to GSheets and GCS but not to BigQuery (api_table_uploads.op_stack_chain_metadata). This meant the BQ table only got updated by the legacy CircleCI notebook runner, which had stopped running since Aug 2025, causing the table to go stale.

- Add BQ upload step to upload_all() in the Dagster pipeline
- Use CSV format with explicit BQ schema to match the legacy table types (DATETIME for date columns, STRING for chain_id) required by downstream views like views.all_chains_metadata
- Remove stale TODO from chainsdaily.py asset docstring