### PR TITLE
chainsmeta: tolerate SystemConfig 4.0.0 removed getters

### DIFF
--- a/src/op_analytics/datasources/chainsmeta/systemconfig/rpc.py
+++ b/src/op_analytics/datasources/chainsmeta/systemconfig/rpc.py
@@ -26,6 +26,19 @@ BLOCK_REQUEST = {
 
 
 # System Config Contract method IDs
+#
+# Not every method exists on every chain's SystemConfig, and chains upgrade at
+# different times, so we tolerate both old and new contract versions indefinitely:
+#
+# - Methods added in newer versions (e.g. operatorFeeScalar) revert on chains
+#   that have not upgraded yet.
+# - batchInbox, startBlock, BATCH_INBOX_SLOT, and START_BLOCK_SLOT were removed
+#   in SystemConfig 4.0.0 (op-contracts v8.0.0), so they revert or return empty
+#   on chains that have upgraded.
+#   See https://github.com/ethereum-optimism/optimism/issues/21614.
+#
+# SystemConfigMetadata.of() records None for any method that reverts or returns
+# an empty result.
 SYSTEM_CONFIG_METHODS = {
     "BATCH_INBOX_SLOT": "0xbc49ce5f",
     "DISPUTE_GAME_FACTORY_SLOT": "0xe2a3285c",
@@ -146,14 +159,17 @@ class SystemConfigMetadata:
     contract_address: str
     block_number: int
     block_timestamp: int
-    batch_inbox_slot: str
+    # batch_inbox_slot and start_block_slot are None on chains running SystemConfig
+    # 4.0.0+ (op-contracts v8.0.0), which removed these getters and cleared the slots.
+    # See https://github.com/ethereum-optimism/optimism/issues/21614.
+    batch_inbox_slot: Optional[str]
     dispute_game_factory_slot: str
     l1_cross_domain_messenger_slot: str
     l1_erc721_bridge_slot: str
     l1_standard_bridge_slot: str
     optimism_mintable_erc20_factory_slot: str
     optimism_portal_slot: str
-    start_block_slot: str
+    start_block_slot: Optional[str]
     unsafe_block_signer_slot: str
     version: Optional[int]
     basefee_scalar: Optional[int]
@@ -213,6 +229,15 @@ class SystemConfigMetadata:
                 data["block_timestamp"] = int(item["result"]["timestamp"], 16)
 
             elif item["id"] in SYSTEM_CONFIG_METHODS:
+                # Some nodes answer an eth_call to a removed method with an empty "0x"
+                # result instead of an "execution reverted" error (e.g. batchInbox and
+                # startBlock on SystemConfig 4.0.0+, see
+                # https://github.com/ethereum-optimism/optimism/issues/21614). Treat it
+                # the same as a revert so the field is recorded as None.
+                if item["result"] == "0x":
+                    failed_methods.append(item["id"])
+                    continue
+
                 data[item["id"]] = item["result"]
 
             else:

--- a/tests/op_analytics/datasources/chainsmeta/systemconfig/test_systemconfigs.py
+++ b/tests/op_analytics/datasources/chainsmeta/systemconfig/test_systemconfigs.py
@@ -581,6 +581,64 @@ def test_decode_response():
     )
 
 
+def test_decode_response_systemconfig_v4_removed_getters():
+    # SystemConfig 4.0.0 (op-contracts v8.0.0) removed the batchInbox and startBlock
+    # getters along with BATCH_INBOX_SLOT and START_BLOCK_SLOT, so calls to them revert
+    # or return empty on upgraded chains while pre-4.0.0 chains still answer them.
+    # See https://github.com/ethereum-optimism/optimism/issues/21614.
+    #
+    # This response mixes both failure shapes: "execution reverted" errors (codes
+    # -32000 and 3) and empty "0x" results. All four fields must decode to None and
+    # the row must still be produced with the remaining fields intact.
+    response: list[dict[Any, Any]] = [
+        {
+            "jsonrpc": "2.0",
+            "id": "block",
+            "result": {"number": "0x15a5a16", "timestamp": "0x684ca13f"},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": "batchInbox",
+            "error": {"code": -32000, "message": "execution reverted"},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": "startBlock",
+            "error": {"code": 3, "message": "execution reverted"},
+        },
+        {"jsonrpc": "2.0", "id": "BATCH_INBOX_SLOT", "result": "0x"},
+        {"jsonrpc": "2.0", "id": "START_BLOCK_SLOT", "result": "0x"},
+        {
+            "jsonrpc": "2.0",
+            "id": "gasLimit",
+            "result": "0x0000000000000000000000000000000000000000000000000000000001c9c380",
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": "owner",
+            "result": "0x00000000000000000000000056121a8612474c3eb65d69a3b871f284705b9bc4",
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": "version",
+            "result": "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000005342e302e30000000000000000000000000000000000000000000000000000000",
+        },
+    ]
+    dummy = RPCManager(system_config_proxy="0x158Fd5715F16Ac1F2Dc959A299B383aAaf9B59EB")
+    actual = SystemConfigMetadata.of(dummy, response)
+
+    assert actual is not None
+    assert actual.batch_inbox is None
+    assert actual.start_block is None
+    assert actual.batch_inbox_slot is None
+    assert actual.start_block_slot is None
+    # Fields that still exist on 4.0.0 decode as usual.
+    assert actual.block_number == 22698518
+    assert actual.gas_limit == 30000000
+    assert actual.owner == "0x56121a8612474c3eb65d69a3b871f284705b9bc4"
+    assert actual.version_hex == "4.0.0"
+
+
 def test_decode():
     assert (
         decode("uint256", "0x0000000000000000000000000000000000000000000000000000000000000834")


### PR DESCRIPTION
SystemConfig 4.0.0 (op-contracts v8.0.0, https://github.com/ethereum-optimism/optimism/pull/21641) removes the `batchInbox()`, `startBlock()`, `BATCH_INBOX_SLOT()`, and `START_BLOCK_SLOT()` getters that the chainsmeta systemconfig ingest calls on every chain. Chains upgrade at different times, so the ingest must tolerate both versions indefinitely.

The pipeline already treats per-method reverts as None (that is how `operatorFeeScalar` and friends work on not-yet-upgraded chains), so reverts from removed getters were already handled. The actual gap: some nodes answer an `eth_call` to a removed method with an empty `0x` result instead of a revert, which previously produced garbage for address fields (`"0x0x"`) or raised for int fields. This PR treats an empty result the same as a revert, marks the two slot annotations `Optional`, and adds a test covering both failure shapes against a 4.0.0 SystemConfig.

No SQL changes — the ClickHouse columns are already `Nullable`. Historical rows keep their values; post-upgrade rows get NULL for the removed fields.

Tests: `uv run pytest tests/op_analytics/datasources/chainsmeta/ -v` → 19 passed; mypy and ruff clean.

Related PRs: https://github.com/ethereum-optimism/optimism/pull/21641 (contracts), https://github.com/ethereum-optimism/specs/pull/922 (spec), https://github.com/ethereum-optimism/superchain-ops/pull/1492 (upgrade tooling), the dev-docs edit rides along in the monorepo PR. Context: ethereum-optimism/optimism#21614.
